### PR TITLE
Add Utility Layouts and corresponding Widgets

### DIFF
--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -58,6 +58,10 @@ set(cockatrice_SOURCES
     src/game/filters/filter_builder.cpp
     src/game/filters/filter_tree.cpp
     src/game/filters/filter_tree_model.cpp
+    src/client/ui/layouts/flow_layout.cpp
+    src/client/ui/layouts/horizontal_flow_layout.cpp
+    src/client/ui/layouts/vertical_flow_layout.cpp
+    src/client/ui/widgets/general/layout_containers/flow_widget.cpp
     src/game/game_scene.cpp
     src/game/game_selector.cpp
     src/game/games_model.cpp

--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -78,10 +78,12 @@ set(cockatrice_SOURCES
     src/utility/logger.cpp
     src/client/ui/widgets/cards/card_info_picture_enlarged_widget.cpp
     src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
+    src/client/ui/widgets/general/display/labeled_input.cpp
     src/main.cpp
     src/server/message_log_widget.cpp
     src/client/ui/layouts/overlap_layout.cpp
     src/client/ui/widgets/general/layout_containers/overlap_widget.cpp
+    src/client/ui/widgets/general/layout_containers/overlap_control_widget.cpp
     src/server/pending_command.cpp
     src/game/phase.cpp
     src/client/ui/phases_toolbar.cpp

--- a/cockatrice/CMakeLists.txt
+++ b/cockatrice/CMakeLists.txt
@@ -80,6 +80,8 @@ set(cockatrice_SOURCES
     src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
     src/main.cpp
     src/server/message_log_widget.cpp
+    src/client/ui/layouts/overlap_layout.cpp
+    src/client/ui/widgets/general/layout_containers/overlap_widget.cpp
     src/server/pending_command.cpp
     src/game/phase.cpp
     src/client/ui/phases_toolbar.cpp

--- a/cockatrice/src/client/ui/layouts/flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/flow_layout.cpp
@@ -20,7 +20,7 @@
  * @param hSpacing The horizontal spacing between items.
  * @param vSpacing The vertical spacing between items.
  */
-FlowLayout::FlowLayout(QWidget *parent, int margin, int hSpacing, int vSpacing)
+FlowLayout::FlowLayout(QWidget *parent, const int margin, const int hSpacing, const int vSpacing)
     : QLayout(parent), horizontalMargin(hSpacing), verticalMargin(vSpacing)
 {
     setContentsMargins(margin, margin, margin, margin);
@@ -60,7 +60,7 @@ bool FlowLayout::hasHeightForWidth() const
  * @param width The available width for arranging items.
  * @return The total height needed to fit all items in rows constrained by the specified width.
  */
-int FlowLayout::heightForWidth(int width) const
+int FlowLayout::heightForWidth(const int width) const
 {
     int height = 0;
     int rowWidth = 0;
@@ -70,6 +70,7 @@ int FlowLayout::heightForWidth(int width) const
         if (item == nullptr || item->isEmpty()) {
             continue;
         }
+
         int itemWidth = item->sizeHint().width() + horizontalSpacing();
         if (rowWidth + itemWidth > width) { // Start a new row if the row width exceeds available width
             height += rowHeight + verticalSpacing();
@@ -134,6 +135,7 @@ int FlowLayout::layoutAllRows(const int originX, const int originY, const int av
         if (item == nullptr || item->isEmpty()) {
             continue;
         }
+
         QSize itemSize = item->sizeHint(); // The suggested size for the item.
         const int itemWidth = itemSize.width() + horizontalSpacing();
 
@@ -235,8 +237,8 @@ void FlowLayout::addItem(QLayoutItem *item)
  */
 int FlowLayout::count() const
 {
-    // Ensure safe conversion by explicitly casting to int. Necessary to silence warnings about narrowing conversion.
-    assert(items.size() <= static_cast<std::size_t>(std::numeric_limits<int>::max()));
+    // Ensure safe conversion by casting the maximum limit to the same type as items.size()
+    assert(items.size() <= static_cast<qsizetype>(std::numeric_limits<int>::max()));
     return static_cast<int>(items.size());
 }
 

--- a/cockatrice/src/client/ui/layouts/flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/flow_layout.cpp
@@ -195,10 +195,8 @@ QSize FlowLayout::sizeHint() const
 {
     QSize size;
     for (const QLayoutItem *item : items) {
-        if (item != nullptr) {
-            if (!item->isEmpty()) {
-                size = size.expandedTo(item->sizeHint());
-            }
+        if (item != nullptr && !item->isEmpty()) {
+            size = size.expandedTo(item->sizeHint());
         }
     }
     return size.isValid() ? size : QSize(0, 0);
@@ -212,10 +210,8 @@ QSize FlowLayout::minimumSize() const
 {
     QSize size;
     for (const QLayoutItem *item : items) {
-        if (item != nullptr) {
-            if (!item->isEmpty()) {
-                size = size.expandedTo(item->minimumSize());
-            }
+        if (item != nullptr && !item->isEmpty()) {
+            size = size.expandedTo(item->minimumSize());
         }
     }
 

--- a/cockatrice/src/client/ui/layouts/flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/flow_layout.cpp
@@ -185,7 +185,6 @@ void FlowLayout::layoutSingleRow(const QVector<QLayoutItem *> &rowItems, int x, 
     }
 }
 
-
 /**
  * @brief Returns the preferred size for this layout.
  * @return The maximum of all item size hints as a QSize.

--- a/cockatrice/src/client/ui/layouts/flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/flow_layout.cpp
@@ -133,10 +133,9 @@ int FlowLayout::layoutAllRows(int originX, int originY, int availableWidth)
     for (QLayoutItem *item : items) {
         if (!(item == nullptr || item->isEmpty())) {
             QSize itemSize = item->sizeHint();                      // The suggested size for the item.
-            int itemWidth = itemSize.width() + horizontalSpacing(); // Includes spacing.
 
             // Check if the item fits in the current row's remaining width.
-            if (currentXPosition + itemWidth > availableWidth) {
+            if (int itemWidth = itemSize.width() + horizontalSpacing(); currentXPosition + itemWidth > availableWidth) {
                 // If not, layout the current row and start a new row.
                 layoutSingleRow(rowItems, originX, currentYPosition);
                 rowItems.clear();                                  // Clear the temporary storage for the new row.
@@ -253,7 +252,7 @@ QLayoutItem *FlowLayout::itemAt(int index) const
  */
 QLayoutItem *FlowLayout::takeAt(int index)
 {
-    return items.takeAt(index);
+    return (index >= 0 && index < items.size()) ? items.takeAt(index) : nullptr;
 }
 
 /**

--- a/cockatrice/src/client/ui/layouts/flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/flow_layout.cpp
@@ -132,7 +132,7 @@ int FlowLayout::layoutAllRows(int originX, int originY, int availableWidth)
     // Iterate through all layout items to arrange them.
     for (QLayoutItem *item : items) {
         if (!(item == nullptr || item->isEmpty())) {
-            QSize itemSize = item->sizeHint();                      // The suggested size for the item.
+            QSize itemSize = item->sizeHint(); // The suggested size for the item.
 
             // Check if the item fits in the current row's remaining width.
             if (int itemWidth = itemSize.width() + horizontalSpacing(); currentXPosition + itemWidth > availableWidth) {

--- a/cockatrice/src/client/ui/layouts/flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/flow_layout.cpp
@@ -127,7 +127,6 @@ int FlowLayout::layoutAllRows(int originX, int originY, int availableWidth)
     int currentXPosition = originX;  // Tracks the x-coordinate for placing items in the current row.
     int currentYPosition = originY;  // Tracks the y-coordinate, updated after each row.
 
-    int rowWidth = 0;  // Tracks the cumulative width of items in the current row.
     int rowHeight = 0; // Tracks the maximum height of items in the current row.
 
     // Iterate through all layout items to arrange them.
@@ -143,13 +142,11 @@ int FlowLayout::layoutAllRows(int originX, int originY, int availableWidth)
                 rowItems.clear();                                  // Clear the temporary storage for the new row.
                 currentXPosition = originX;                        // Reset x-position to the start of the new row.
                 currentYPosition += rowHeight + verticalSpacing(); // Move y-position down for the new row.
-                rowWidth = 0;                                      // Reset row width for the new row.
                 rowHeight = 0;                                     // Reset row height for the new row.
             }
 
             // Add the item to the current row.
             rowItems.append(item);
-            rowWidth += itemSize.width() + horizontalSpacing();         // Accumulate row width.
             rowHeight = qMax(rowHeight, itemSize.height());             // Update the row height to the tallest item.
             currentXPosition += itemSize.width() + horizontalSpacing(); // Move x-position for the next item.
         }

--- a/cockatrice/src/client/ui/layouts/flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/flow_layout.cpp
@@ -1,0 +1,246 @@
+/**
+ * @file flow_layout.cpp
+ * @brief Implementation of the FlowLayout class, a custom layout for dynamically organizing widgets
+ * in rows within the constraints of available width or parent scroll areas.
+ */
+
+#include "flow_layout.h"
+
+#include "../widgets/general/layout_containers/flow_widget.h"
+
+#include <QDebug>
+#include <QLayoutItem>
+#include <QScrollArea>
+
+/**
+ * @brief Constructs a FlowLayout instance with the specified parent widget.
+ * @param parent The parent widget for this layout.
+ */
+FlowLayout::FlowLayout(QWidget *parent) : QLayout(parent)
+{
+}
+
+/**
+ * @brief Destructor for FlowLayout, which cleans up all items in the layout.
+ */
+FlowLayout::~FlowLayout()
+{
+    QLayoutItem *item;
+    while ((item = FlowLayout::takeAt(0))) {
+        delete item;
+    }
+}
+
+/**
+ * @brief Indicates the layout's support for expansion in both horizontal and vertical directions.
+ * @return The orientations (Qt::Horizontal | Qt::Vertical) this layout can expand to fill.
+ */
+Qt::Orientations FlowLayout::expandingDirections() const
+{
+    return Qt::Horizontal | Qt::Vertical;
+}
+
+/**
+ * @brief Indicates that this layout's height depends on its width.
+ * @return True, as the layout adjusts its height to fit the specified width.
+ */
+bool FlowLayout::hasHeightForWidth() const
+{
+    return true;
+}
+
+/**
+ * @brief Calculates the required height to display all items within the specified width.
+ * @param width The available width for arranging items.
+ * @return The total height needed to fit all items in rows constrained by the specified width.
+ */
+int FlowLayout::heightForWidth(int width) const
+{
+    int height = 0;
+    int rowWidth = 0;
+    int rowHeight = 0;
+
+    for (QLayoutItem *item : items) {
+        int itemWidth = item->sizeHint().width();
+        if (rowWidth + itemWidth > width) { // Start a new row if the row width exceeds available width
+            height += rowHeight;
+            rowWidth = itemWidth;
+            rowHeight = item->sizeHint().height();
+        } else {
+            rowWidth += itemWidth;
+            rowHeight = qMax(rowHeight, item->sizeHint().height());
+        }
+    }
+    height += rowHeight; // Add the final row's height
+    return height;
+}
+
+/**
+ * @brief Arranges layout items in rows within the specified rectangle bounds.
+ * @param rect The area within which to position layout items.
+ */
+void FlowLayout::setGeometry(const QRect &rect)
+{
+    QLayout::setGeometry(rect);
+    int availableWidth = qMax(rect.width(), getParentScrollAreaWidth());
+    int totalHeight = layoutRows(rect.x(), rect.y(), availableWidth);
+
+    QWidget *parentWidgetPtr = parentWidget();
+    if (parentWidgetPtr) {
+        parentWidgetPtr->setMinimumSize(availableWidth, totalHeight);
+    }
+}
+
+/**
+ * @brief Arranges items in rows based on the available width.
+ * @param originX The starting x-coordinate for the row layout.
+ * @param originY The starting y-coordinate for the row layout.
+ * @param availableWidth The available width to lay out items.
+ * @return The y-coordinate of the final row's end position.
+ */
+int FlowLayout::layoutRows(int originX, int originY, int availableWidth)
+{
+    QVector<QLayoutItem *> rowItems;
+    int currentXPosition = originX;
+    int currentYPosition = originY;
+
+    int rowWidth = 0;
+    int rowHeight = 0;
+
+    for (QLayoutItem *item : items) {
+        QSize itemSize = item->sizeHint();
+        if (currentXPosition + itemSize.width() > availableWidth) {
+            layoutRow(rowItems, originX, currentYPosition);
+            rowItems.clear();
+            currentXPosition = originX;
+            currentYPosition += rowHeight;
+            rowWidth = 0;
+            rowHeight = 0;
+        }
+        rowItems.append(item);
+        rowWidth += itemSize.width();
+        rowHeight = qMax(rowHeight, itemSize.height());
+        currentXPosition += itemSize.width();
+    }
+
+    layoutRow(rowItems, originX, currentYPosition);
+
+    return currentYPosition + rowHeight;
+}
+
+/**
+ * @brief Helper function for arranging a single row of items within specified bounds.
+ * @param rowItems Items to be arranged in the row.
+ * @param x The x-coordinate for starting the row.
+ * @param y The y-coordinate for starting the row.
+ */
+void FlowLayout::layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y)
+{
+    for (QLayoutItem *item : rowItems) {
+        QSize itemMaxSize = item->widget()->maximumSize();
+        int itemWidth = qMin(item->sizeHint().width(), itemMaxSize.width());
+        int itemHeight = qMin(item->sizeHint().height(), itemMaxSize.height());
+        item->setGeometry(QRect(QPoint(x, y), QSize(itemWidth, itemHeight)));
+        x += itemWidth;
+    }
+}
+
+/**
+ * @brief Returns the preferred size for this layout.
+ * @return The maximum of all item size hints as a QSize.
+ */
+QSize FlowLayout::sizeHint() const
+{
+    QSize size;
+    for (QLayoutItem *item : items) {
+        size = size.expandedTo(item->sizeHint());
+    }
+    return size.isValid() ? size : QSize(0, 0);
+}
+
+/**
+ * @brief Returns the minimum size required to display all layout items.
+ * @return The minimum QSize needed by the layout.
+ */
+QSize FlowLayout::minimumSize() const
+{
+    QSize size;
+    for (QLayoutItem *item : items) {
+        size = size.expandedTo(item->minimumSize());
+    }
+
+    size.setWidth(qMin(size.width(), getParentScrollAreaWidth()));
+    size.setHeight(qMin(size.height(), getParentScrollAreaHeight()));
+
+    return size.isValid() ? size : QSize(0, 0);
+}
+
+/**
+ * @brief Adds a new item to the layout.
+ * @param item The layout item to add.
+ */
+void FlowLayout::addItem(QLayoutItem *item)
+{
+    items.append(item);
+}
+
+/**
+ * @brief Retrieves the count of items in the layout.
+ * @return The number of layout items.
+ */
+int FlowLayout::count() const
+{
+    return items.size();
+}
+
+/**
+ * @brief Returns the layout item at the specified index.
+ * @param index The index of the item to retrieve.
+ * @return A pointer to the item at the specified index, or nullptr if out of range.
+ */
+QLayoutItem *FlowLayout::itemAt(int index) const
+{
+    return items.value(index);
+}
+
+/**
+ * @brief Removes and returns the item at the specified index.
+ * @param index The index of the item to remove.
+ * @return A pointer to the removed item, or nullptr if out of range.
+ */
+QLayoutItem *FlowLayout::takeAt(int index)
+{
+    return (index >= 0 && index < items.size()) ? items.takeAt(index) : nullptr;
+}
+
+/**
+ * @brief Gets the width of the parent scroll area, if any.
+ * @return The width of the scroll area's viewport, or 0 if not found.
+ */
+int FlowLayout::getParentScrollAreaWidth() const
+{
+    QWidget *parent = parentWidget();
+    while (parent) {
+        if (QScrollArea *scrollArea = qobject_cast<QScrollArea *>(parent)) {
+            return scrollArea->viewport()->width();
+        }
+        parent = parent->parentWidget();
+    }
+    return 0;
+}
+
+/**
+ * @brief Gets the height of the parent scroll area, if any.
+ * @return The height of the scroll area's viewport, or 0 if not found.
+ */
+int FlowLayout::getParentScrollAreaHeight() const
+{
+    QWidget *parent = parentWidget();
+    while (parent) {
+        if (QScrollArea *scrollArea = qobject_cast<QScrollArea *>(parent)) {
+            return scrollArea->viewport()->height();
+        }
+        parent = parent->parentWidget();
+    }
+    return 0;
+}

--- a/cockatrice/src/client/ui/layouts/flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/flow_layout.h
@@ -1,0 +1,35 @@
+#ifndef FLOW_LAYOUT_H
+#define FLOW_LAYOUT_H
+
+#include <QLayout>
+#include <QList>
+#include <QWidget>
+
+class FlowLayout : public QLayout
+{
+public:
+    explicit FlowLayout(QWidget *parent = nullptr);
+    ~FlowLayout();
+
+    void addItem(QLayoutItem *item) override;
+    int count() const override;
+    QLayoutItem *itemAt(int index) const override;
+    QLayoutItem *takeAt(int index) override;
+
+    Qt::Orientations expandingDirections() const override;
+    bool hasHeightForWidth() const override;
+    int heightForWidth(int width) const override;
+    int getParentScrollAreaWidth() const;
+    int getParentScrollAreaHeight() const;
+
+    void setGeometry(const QRect &rect) override;
+    virtual int layoutRows(int originX, int originY, int availableWidth);
+    virtual void layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y);
+    QSize sizeHint() const override;
+    QSize minimumSize() const override;
+
+protected:
+    QList<QLayoutItem *> items; // List to store layout items
+};
+
+#endif // FLOWLAYOUT_H

--- a/cockatrice/src/client/ui/layouts/flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/flow_layout.h
@@ -4,32 +4,38 @@
 #include <QLayout>
 #include <QList>
 #include <QWidget>
+#include <qstyle.h>
 
 class FlowLayout : public QLayout
 {
 public:
     explicit FlowLayout(QWidget *parent = nullptr);
+    FlowLayout(QWidget *parent, int margin, int hSpacing, int vSpacing);
     ~FlowLayout();
 
     void addItem(QLayoutItem *item) override;
     int count() const override;
     QLayoutItem *itemAt(int index) const override;
     QLayoutItem *takeAt(int index) override;
+    int horizontalSpacing() const;
 
     Qt::Orientations expandingDirections() const override;
     bool hasHeightForWidth() const override;
     int heightForWidth(int width) const override;
+    int verticalSpacing() const;
+    int doLayout(const QRect &rect, bool testOnly) const;
+    int smartSpacing(QStyle::PixelMetric pm) const;
     int getParentScrollAreaWidth() const;
     int getParentScrollAreaHeight() const;
 
     void setGeometry(const QRect &rect) override;
-    virtual int layoutRows(int originX, int originY, int availableWidth);
-    virtual void layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y);
     QSize sizeHint() const override;
     QSize minimumSize() const override;
 
 protected:
     QList<QLayoutItem *> items; // List to store layout items
+    int m_hSpace;
+    int m_vSpace;
 };
 
 #endif // FLOWLAYOUT_H

--- a/cockatrice/src/client/ui/layouts/flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/flow_layout.h
@@ -29,6 +29,8 @@ public:
     int getParentScrollAreaHeight() const;
 
     void setGeometry(const QRect &rect) override;
+    virtual int layoutRows(int originX, int originY, int availableWidth);
+    virtual void layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y);
     QSize sizeHint() const override;
     QSize minimumSize() const override;
 

--- a/cockatrice/src/client/ui/layouts/flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/flow_layout.h
@@ -29,15 +29,15 @@ public:
     int getParentScrollAreaHeight() const;
 
     void setGeometry(const QRect &rect) override;
-    virtual int layoutRows(int originX, int originY, int availableWidth);
-    virtual void layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y);
+    virtual int layoutAllRows(int originX, int originY, int availableWidth);
+    virtual void layoutSingleRow(const QVector<QLayoutItem *> &rowItems, int x, int y);
     QSize sizeHint() const override;
     QSize minimumSize() const override;
 
 protected:
     QList<QLayoutItem *> items; // List to store layout items
-    int m_hSpace;
-    int m_vSpace;
+    int horizontalMargin;
+    int verticalMargin;
 };
 
 #endif // FLOWLAYOUT_H

--- a/cockatrice/src/client/ui/layouts/flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/flow_layout.h
@@ -11,28 +11,28 @@ class FlowLayout : public QLayout
 public:
     explicit FlowLayout(QWidget *parent = nullptr);
     FlowLayout(QWidget *parent, int margin, int hSpacing, int vSpacing);
-    ~FlowLayout();
+    ~FlowLayout() override;
 
     void addItem(QLayoutItem *item) override;
-    int count() const override;
-    QLayoutItem *itemAt(int index) const override;
+    [[nodiscard]] int count() const override;
+    [[nodiscard]] QLayoutItem *itemAt(int index) const override;
     QLayoutItem *takeAt(int index) override;
-    int horizontalSpacing() const;
+    [[nodiscard]] int horizontalSpacing() const;
 
-    Qt::Orientations expandingDirections() const override;
-    bool hasHeightForWidth() const override;
-    int heightForWidth(int width) const override;
-    int verticalSpacing() const;
-    int doLayout(const QRect &rect, bool testOnly) const;
-    int smartSpacing(QStyle::PixelMetric pm) const;
-    int getParentScrollAreaWidth() const;
-    int getParentScrollAreaHeight() const;
+    [[nodiscard]] Qt::Orientations expandingDirections() const override;
+    [[nodiscard]] bool hasHeightForWidth() const override;
+    [[nodiscard]] int heightForWidth(int width) const override;
+    [[nodiscard]] int verticalSpacing() const;
+    [[nodiscard]] int doLayout(const QRect &rect, bool testOnly) const;
+    [[nodiscard]] int smartSpacing(QStyle::PixelMetric pm) const;
+    [[nodiscard]] int getParentScrollAreaWidth() const;
+    [[nodiscard]] int getParentScrollAreaHeight() const;
 
     void setGeometry(const QRect &rect) override;
     virtual int layoutAllRows(int originX, int originY, int availableWidth);
     virtual void layoutSingleRow(const QVector<QLayoutItem *> &rowItems, int x, int y);
-    QSize sizeHint() const override;
-    QSize minimumSize() const override;
+    [[nodiscard]] QSize sizeHint() const override;
+    [[nodiscard]] QSize minimumSize() const override;
 
 protected:
     QList<QLayoutItem *> items; // List to store layout items
@@ -40,4 +40,4 @@ protected:
     int verticalMargin;
 };
 
-#endif // FLOWLAYOUT_H
+#endif // FLOW_LAYOUT_H

--- a/cockatrice/src/client/ui/layouts/horizontal_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/horizontal_flow_layout.cpp
@@ -84,7 +84,6 @@ int HorizontalFlowLayout::layoutAllColumns(int originX, int originY, int availab
     int currentYPosition = originY;  // Tracks the y-coordinate, resetting for each new column
 
     int colWidth = 0;  // Tracks the maximum width of items in the current column
-    int colHeight = 0; // Tracks the cumulative height of items in the current column
 
     for (QLayoutItem *item : items) {
         QSize itemSize = item->sizeHint(); // The suggested size for the current item
@@ -97,12 +96,10 @@ int HorizontalFlowLayout::layoutAllColumns(int originX, int originY, int availab
             currentYPosition = originY;   // Reset y-position to the column's start
             currentXPosition += colWidth; // Move x-position to the next column
             colWidth = 0;                 // Reset column width for the new column
-            colHeight = 0;                // Reset column height for the new column
         }
 
         // Add the item to the current column
         colItems.append(item);
-        colHeight += itemSize.height();              // Accumulate the column's total height
         colWidth = qMax(colWidth, itemSize.width()); // Update the column's width to the widest item
         currentYPosition += itemSize.height();       // Move y-position for the next item
     }

--- a/cockatrice/src/client/ui/layouts/horizontal_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/horizontal_flow_layout.cpp
@@ -8,7 +8,7 @@
  * @param hSpacing The horizontal spacing between items.
  * @param vSpacing The vertical spacing between items.
  */
-HorizontalFlowLayout::HorizontalFlowLayout(QWidget *parent, int margin, int hSpacing, int vSpacing)
+HorizontalFlowLayout::HorizontalFlowLayout(QWidget *parent, const int margin, const int hSpacing, const int vSpacing)
     : FlowLayout(parent, margin, hSpacing, vSpacing)
 {
 }
@@ -30,23 +30,25 @@ HorizontalFlowLayout::~HorizontalFlowLayout()
  * @param height The available height for arranging layout items.
  * @return The total width required to fit all items, organized in columns constrained by the given height.
  */
-int HorizontalFlowLayout::heightForWidth(int height) const
+int HorizontalFlowLayout::heightForWidth(const int height) const
 {
     int width = 0;
     int colWidth = 0;
     int colHeight = 0;
 
-    for (QLayoutItem *item : items) {
-        if (!(item == nullptr || item->isEmpty())) {
-            int itemHeight = item->sizeHint().height();
-            if (colHeight + itemHeight > height) {
-                width += colWidth;
-                colHeight = itemHeight;
-                colWidth = item->sizeHint().width();
-            } else {
-                colHeight += itemHeight;
-                colWidth = qMax(colWidth, item->sizeHint().width());
-            }
+    for (const QLayoutItem *item : items) {
+        if (item == nullptr || item->isEmpty()) {
+            continue;
+        }
+
+        int itemHeight = item->sizeHint().height();
+        if (colHeight + itemHeight > height) {
+            width += colWidth;
+            colHeight = itemHeight;
+            colWidth = item->sizeHint().width();
+        } else {
+            colHeight += itemHeight;
+            colWidth = qMax(colWidth, item->sizeHint().width());
         }
     }
     width += colWidth; // Add width of the last column
@@ -59,12 +61,11 @@ int HorizontalFlowLayout::heightForWidth(int height) const
  */
 void HorizontalFlowLayout::setGeometry(const QRect &rect)
 {
-    int availableHeight = qMax(rect.height(), getParentScrollAreaHeight());
+    const int availableHeight = qMax(rect.height(), getParentScrollAreaHeight());
 
-    int totalWidth = layoutAllColumns(rect.x(), rect.y(), availableHeight);
+    const int totalWidth = layoutAllColumns(rect.x(), rect.y(), availableHeight);
 
-    QWidget *parentWidgetPtr = parentWidget();
-    if (parentWidgetPtr) {
+    if (QWidget *parentWidgetPtr = parentWidget()) {
         parentWidgetPtr->setMinimumSize(totalWidth, availableHeight);
     }
 }
@@ -77,7 +78,7 @@ void HorizontalFlowLayout::setGeometry(const QRect &rect)
  * @param availableHeight The height within which each column is constrained.
  * @return The total width after arranging all columns.
  */
-int HorizontalFlowLayout::layoutAllColumns(int originX, int originY, int availableHeight)
+int HorizontalFlowLayout::layoutAllColumns(const int originX, const int originY, const int availableHeight)
 {
     QVector<QLayoutItem *> colItems; // Holds items for the current column
     int currentXPosition = originX;  // Tracks the x-coordinate while placing items
@@ -86,6 +87,10 @@ int HorizontalFlowLayout::layoutAllColumns(int originX, int originY, int availab
     int colWidth = 0; // Tracks the maximum width of items in the current column
 
     for (QLayoutItem *item : items) {
+        if (item == nullptr || item->isEmpty()) {
+            continue;
+        }
+
         QSize itemSize = item->sizeHint(); // The suggested size for the current item
 
         // Check if the current item fits in the remaining height of the current column
@@ -117,15 +122,15 @@ int HorizontalFlowLayout::layoutAllColumns(int originX, int originY, int availab
  * @param x The starting x-coordinate for the column.
  * @param y The starting y-coordinate for the column.
  */
-void HorizontalFlowLayout::layoutSingleColumn(const QVector<QLayoutItem *> &colItems, int x, int y)
+void HorizontalFlowLayout::layoutSingleColumn(const QVector<QLayoutItem *> &colItems, const int x, int y)
 {
     for (QLayoutItem *item : colItems) {
         if (!(item == nullptr || item->isEmpty())) {
             // Get the maximum allowed size for the item
             QSize itemMaxSize = item->widget()->maximumSize();
             // Constrain the item's width and height to its size hint or maximum size
-            int itemWidth = qMin(item->sizeHint().width(), itemMaxSize.width());
-            int itemHeight = qMin(item->sizeHint().height(), itemMaxSize.height());
+            const int itemWidth = qMin(item->sizeHint().width(), itemMaxSize.width());
+            const int itemHeight = qMin(item->sizeHint().height(), itemMaxSize.height());
             // Set the item's geometry based on the computed size and position
             item->setGeometry(QRect(QPoint(x, y), QSize(itemWidth, itemHeight)));
             // Move the y-position down by the item's height to place the next item below

--- a/cockatrice/src/client/ui/layouts/horizontal_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/horizontal_flow_layout.cpp
@@ -1,0 +1,128 @@
+#include "horizontal_flow_layout.h"
+
+/**
+ * @brief Constructs a HorizontalFlowLayout instance with the specified parent widget.
+ *        This layout arranges items in columns within the given height, automatically adjusting its width.
+ * @param parent The parent widget to which this layout belongs.
+ */
+HorizontalFlowLayout::HorizontalFlowLayout(QWidget *parent) : FlowLayout(parent)
+{
+}
+
+/**
+ * @brief Destructor for HorizontalFlowLayout, responsible for cleaning up layout items.
+ */
+HorizontalFlowLayout::~HorizontalFlowLayout()
+{
+    QLayoutItem *item;
+    while ((item = FlowLayout::takeAt(0))) {
+        delete item;
+    }
+}
+
+/**
+ * @brief Indicates that the layout has a variable width based on its height.
+ * @return True, as the layout adjusts its width according to the available height.
+ */
+bool HorizontalFlowLayout::hasHeightForWidth() const
+{
+    return true;
+}
+
+/**
+ * @brief Calculates the required width to display all items, given a specified height.
+ *        This method arranges items into columns and determines the total width needed.
+ * @param height The available height for arranging layout items.
+ * @return The total width required to fit all items, organized in columns constrained by the given height.
+ */
+int HorizontalFlowLayout::heightForWidth(int height) const
+{
+    int width = 0;
+    int rowWidth = 0;
+    int rowHeight = 0;
+
+    for (QLayoutItem *item : items) {
+        int itemHeight = item->sizeHint().height();
+        if (rowHeight + itemHeight > height) {
+            width += rowWidth;
+            rowHeight = itemHeight;
+            rowWidth = item->sizeHint().width();
+        } else {
+            rowHeight += itemHeight;
+            rowWidth = qMax(rowWidth, item->sizeHint().width());
+        }
+    }
+    width += rowWidth; // Add width of the last column
+    return width;
+}
+
+/**
+ * @brief Sets the geometry of the layout items, arranging them in columns within the given height.
+ * @param rect The rectangle area defining the layout space.
+ */
+void HorizontalFlowLayout::setGeometry(const QRect &rect)
+{
+    int availableHeight = qMax(rect.height(), getParentScrollAreaHeight());
+
+    int totalWidth = layoutRows(rect.x(), rect.y(), availableHeight);
+
+    QWidget *parentWidgetPtr = parentWidget();
+    if (parentWidgetPtr) {
+        parentWidgetPtr->setMinimumSize(availableHeight, totalWidth);
+    }
+}
+
+/**
+ * @brief Lays out items into columns according to the available height, starting from a given origin.
+ *        Each column is arranged within `availableHeight`, wrapping to a new column as necessary.
+ * @param originX The x-coordinate for the layout start position.
+ * @param originY The y-coordinate for the layout start position.
+ * @param availableHeight The height within which each column is constrained.
+ * @return The total width after arranging all columns.
+ */
+int HorizontalFlowLayout::layoutRows(int originX, int originY, int availableHeight)
+{
+    QVector<QLayoutItem *> rowItems;
+    int currentXPosition = originX;
+    int currentYPosition = originY;
+
+    int rowWidth = 0;
+    int rowHeight = 0;
+
+    for (QLayoutItem *item : items) {
+        QSize itemSize = item->sizeHint();
+        if (currentYPosition + itemSize.height() > availableHeight) {
+            layoutRow(rowItems, currentXPosition, originY);
+            rowItems.clear();
+            currentYPosition = originY;
+            currentXPosition += rowWidth;
+            rowWidth = 0;
+            rowHeight = 0;
+        }
+        rowItems.append(item);
+        rowHeight += itemSize.height();
+        rowWidth = qMax(rowWidth, itemSize.width());
+        currentYPosition += itemSize.height();
+    }
+
+    layoutRow(rowItems, currentXPosition, originY);
+
+    return currentXPosition + rowWidth;
+}
+
+/**
+ * @brief Arranges a single column of items within specified x and y starting positions.
+ * @param rowItems A list of items to be arranged in the column.
+ * @param x The starting x-coordinate for the column.
+ * @param y The starting y-coordinate for the column.
+ */
+void HorizontalFlowLayout::layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y)
+{
+    for (QLayoutItem *item : rowItems) {
+        QSize itemMaxSize = item->widget()->maximumSize();
+        int itemWidth = qMin(item->sizeHint().width(), itemMaxSize.width());
+        int itemHeight = qMin(item->sizeHint().height(), itemMaxSize.height());
+        item->setGeometry(QRect(QPoint(x, y), QSize(itemWidth, itemHeight)));
+        y += itemHeight;
+    }
+}

--- a/cockatrice/src/client/ui/layouts/horizontal_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/horizontal_flow_layout.cpp
@@ -83,7 +83,7 @@ int HorizontalFlowLayout::layoutAllColumns(int originX, int originY, int availab
     int currentXPosition = originX;  // Tracks the x-coordinate while placing items
     int currentYPosition = originY;  // Tracks the y-coordinate, resetting for each new column
 
-    int colWidth = 0;  // Tracks the maximum width of items in the current column
+    int colWidth = 0; // Tracks the maximum width of items in the current column
 
     for (QLayoutItem *item : items) {
         QSize itemSize = item->sizeHint(); // The suggested size for the current item

--- a/cockatrice/src/client/ui/layouts/horizontal_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/horizontal_flow_layout.cpp
@@ -9,7 +9,7 @@
  * @param vSpacing The vertical spacing between items.
  */
 HorizontalFlowLayout::HorizontalFlowLayout(QWidget *parent, int margin, int hSpacing, int vSpacing)
-: FlowLayout(parent, margin, hSpacing, vSpacing)
+    : FlowLayout(parent, margin, hSpacing, vSpacing)
 {
 }
 

--- a/cockatrice/src/client/ui/layouts/horizontal_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/horizontal_flow_layout.cpp
@@ -25,15 +25,6 @@ HorizontalFlowLayout::~HorizontalFlowLayout()
 }
 
 /**
- * @brief Indicates that the layout has a variable width based on its height.
- * @return True, as the layout adjusts its width according to the available height.
- */
-bool HorizontalFlowLayout::hasHeightForWidth() const
-{
-    return true;
-}
-
-/**
  * @brief Calculates the required width to display all items, given a specified height.
  *        This method arranges items into columns and determines the total width needed.
  * @param height The available height for arranging layout items.
@@ -46,14 +37,16 @@ int HorizontalFlowLayout::heightForWidth(int height) const
     int colHeight = 0;
 
     for (QLayoutItem *item : items) {
-        int itemHeight = item->sizeHint().height();
-        if (colHeight + itemHeight > height) {
-            width += colWidth;
-            colHeight = itemHeight;
-            colWidth = item->sizeHint().width();
-        } else {
-            colHeight += itemHeight;
-            colWidth = qMax(colWidth, item->sizeHint().width());
+        if (!(item == nullptr || item->isEmpty())) {
+            int itemHeight = item->sizeHint().height();
+            if (colHeight + itemHeight > height) {
+                width += colWidth;
+                colHeight = itemHeight;
+                colWidth = item->sizeHint().width();
+            } else {
+                colHeight += itemHeight;
+                colWidth = qMax(colWidth, item->sizeHint().width());
+            }
         }
     }
     width += colWidth; // Add width of the last column
@@ -68,7 +61,7 @@ void HorizontalFlowLayout::setGeometry(const QRect &rect)
 {
     int availableHeight = qMax(rect.height(), getParentScrollAreaHeight());
 
-    int totalWidth = layoutColumns(rect.x(), rect.y(), availableHeight);
+    int totalWidth = layoutAllColumns(rect.x(), rect.y(), availableHeight);
 
     QWidget *parentWidgetPtr = parentWidget();
     if (parentWidgetPtr) {
@@ -84,33 +77,40 @@ void HorizontalFlowLayout::setGeometry(const QRect &rect)
  * @param availableHeight The height within which each column is constrained.
  * @return The total width after arranging all columns.
  */
-int HorizontalFlowLayout::layoutColumns(int originX, int originY, int availableHeight)
+int HorizontalFlowLayout::layoutAllColumns(int originX, int originY, int availableHeight)
 {
-    QVector<QLayoutItem *> colItems;
-    int currentXPosition = originX;
-    int currentYPosition = originY;
+    QVector<QLayoutItem *> colItems; // Holds items for the current column
+    int currentXPosition = originX;  // Tracks the x-coordinate while placing items
+    int currentYPosition = originY;  // Tracks the y-coordinate, resetting for each new column
 
-    int colWidth = 0;
-    int colHeight = 0;
+    int colWidth = 0;  // Tracks the maximum width of items in the current column
+    int colHeight = 0; // Tracks the cumulative height of items in the current column
 
     for (QLayoutItem *item : items) {
-        QSize itemSize = item->sizeHint();
+        QSize itemSize = item->sizeHint(); // The suggested size for the current item
+
+        // Check if the current item fits in the remaining height of the current column
         if (currentYPosition + itemSize.height() > availableHeight) {
-            layoutColumn(colItems, currentXPosition, originY);
-            colItems.clear();
-            currentYPosition = originY;
-            currentXPosition += colWidth;
-            colWidth = 0;
-            colHeight = 0;
+            // If not, layout the current column and start a new column
+            layoutSingleColumn(colItems, currentXPosition, originY);
+            colItems.clear();             // Reset the list for the new column
+            currentYPosition = originY;   // Reset y-position to the column's start
+            currentXPosition += colWidth; // Move x-position to the next column
+            colWidth = 0;                 // Reset column width for the new column
+            colHeight = 0;                // Reset column height for the new column
         }
+
+        // Add the item to the current column
         colItems.append(item);
-        colHeight += itemSize.height();
-        colWidth = qMax(colWidth, itemSize.width());
-        currentYPosition += itemSize.height();
+        colHeight += itemSize.height();              // Accumulate the column's total height
+        colWidth = qMax(colWidth, itemSize.width()); // Update the column's width to the widest item
+        currentYPosition += itemSize.height();       // Move y-position for the next item
     }
 
-    layoutColumn(colItems, currentXPosition, originY);
+    // Layout the final column if there are any remaining items
+    layoutSingleColumn(colItems, currentXPosition, originY);
 
+    // Return the total width used, including the last column's width
     return currentXPosition + colWidth;
 }
 
@@ -120,13 +120,19 @@ int HorizontalFlowLayout::layoutColumns(int originX, int originY, int availableH
  * @param x The starting x-coordinate for the column.
  * @param y The starting y-coordinate for the column.
  */
-void HorizontalFlowLayout::layoutColumn(const QVector<QLayoutItem *> &colItems, int x, int y)
+void HorizontalFlowLayout::layoutSingleColumn(const QVector<QLayoutItem *> &colItems, int x, int y)
 {
     for (QLayoutItem *item : colItems) {
-        QSize itemMaxSize = item->widget()->maximumSize();
-        int itemWidth = qMin(item->sizeHint().width(), itemMaxSize.width());
-        int itemHeight = qMin(item->sizeHint().height(), itemMaxSize.height());
-        item->setGeometry(QRect(QPoint(x, y), QSize(itemWidth, itemHeight)));
-        y += itemHeight;
+        if (!(item == nullptr || item->isEmpty())) {
+            // Get the maximum allowed size for the item
+            QSize itemMaxSize = item->widget()->maximumSize();
+            // Constrain the item's width and height to its size hint or maximum size
+            int itemWidth = qMin(item->sizeHint().width(), itemMaxSize.width());
+            int itemHeight = qMin(item->sizeHint().height(), itemMaxSize.height());
+            // Set the item's geometry based on the computed size and position
+            item->setGeometry(QRect(QPoint(x, y), QSize(itemWidth, itemHeight)));
+            // Move the y-position down by the item's height to place the next item below
+            y += itemHeight;
+        }
     }
 }

--- a/cockatrice/src/client/ui/layouts/horizontal_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/horizontal_flow_layout.cpp
@@ -125,19 +125,18 @@ int HorizontalFlowLayout::layoutAllColumns(const int originX, const int originY,
 void HorizontalFlowLayout::layoutSingleColumn(const QVector<QLayoutItem *> &colItems, const int x, int y)
 {
     for (QLayoutItem *item : colItems) {
-        if (item != nullptr) {
-            if (item->isEmpty()) {
-                continue;
-            }
-            // Get the maximum allowed size for the item
-            QSize itemMaxSize = item->widget()->maximumSize();
-            // Constrain the item's width and height to its size hint or maximum size
-            const int itemWidth = qMin(item->sizeHint().width(), itemMaxSize.width());
-            const int itemHeight = qMin(item->sizeHint().height(), itemMaxSize.height());
-            // Set the item's geometry based on the computed size and position
-            item->setGeometry(QRect(QPoint(x, y), QSize(itemWidth, itemHeight)));
-            // Move the y-position down by the item's height to place the next item below
-            y += itemHeight;
+        if (item != nullptr && item->isEmpty()) {
+            continue;
         }
+
+        // Get the maximum allowed size for the item
+        QSize itemMaxSize = item->widget()->maximumSize();
+        // Constrain the item's width and height to its size hint or maximum size
+        const int itemWidth = qMin(item->sizeHint().width(), itemMaxSize.width());
+        const int itemHeight = qMin(item->sizeHint().height(), itemMaxSize.height());
+        // Set the item's geometry based on the computed size and position
+        item->setGeometry(QRect(QPoint(x, y), QSize(itemWidth, itemHeight)));
+        // Move the y-position down by the item's height to place the next item below
+        y += itemHeight;
     }
 }

--- a/cockatrice/src/client/ui/layouts/horizontal_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/horizontal_flow_layout.cpp
@@ -125,7 +125,10 @@ int HorizontalFlowLayout::layoutAllColumns(const int originX, const int originY,
 void HorizontalFlowLayout::layoutSingleColumn(const QVector<QLayoutItem *> &colItems, const int x, int y)
 {
     for (QLayoutItem *item : colItems) {
-        if (!(item == nullptr || item->isEmpty())) {
+        if (item != nullptr) {
+            if (item->isEmpty()) {
+                continue;
+            }
             // Get the maximum allowed size for the item
             QSize itemMaxSize = item->widget()->maximumSize();
             // Constrain the item's width and height to its size hint or maximum size

--- a/cockatrice/src/client/ui/layouts/horizontal_flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/horizontal_flow_layout.h
@@ -9,11 +9,11 @@ public:
     explicit HorizontalFlowLayout(QWidget *parent = nullptr, int margin = 0, int hSpacing = 0, int vSpacing = 0);
     ~HorizontalFlowLayout() override;
 
-    int heightForWidth(int width) const override;
+    [[nodiscard]] int heightForWidth(int height) const override;
 
     void setGeometry(const QRect &rect) override;
-    int layoutAllColumns(int originX, int originY, int availableWidth);
-    void layoutSingleColumn(const QVector<QLayoutItem *> &rowItems, int x, int y);
+    int layoutAllColumns(int originX, int originY, int availableHeight);
+    static void layoutSingleColumn(const QVector<QLayoutItem *> &colItems, int x, int y);
 };
 
 #endif // HORIZONTAL_FLOW_LAYOUT_H

--- a/cockatrice/src/client/ui/layouts/horizontal_flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/horizontal_flow_layout.h
@@ -9,7 +9,6 @@ public:
     explicit HorizontalFlowLayout(QWidget *parent = nullptr, int margin = 0, int hSpacing = 0, int vSpacing = 0);
     ~HorizontalFlowLayout() override;
 
-    bool hasHeightForWidth() const override;
     int heightForWidth(int width) const override;
 
     void setGeometry(const QRect &rect) override;

--- a/cockatrice/src/client/ui/layouts/horizontal_flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/horizontal_flow_layout.h
@@ -6,15 +6,15 @@
 class HorizontalFlowLayout : public FlowLayout
 {
 public:
-    explicit HorizontalFlowLayout(QWidget *parent = nullptr);
+    explicit HorizontalFlowLayout(QWidget *parent = nullptr, int margin = 0, int hSpacing = 0, int vSpacing = 0);
     ~HorizontalFlowLayout() override;
 
     bool hasHeightForWidth() const override;
     int heightForWidth(int width) const override;
 
     void setGeometry(const QRect &rect) override;
-    int layoutRows(int originX, int originY, int availableWidth) override;
-    void layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y) override;
+    int layoutColumns(int originX, int originY, int availableWidth);
+    void layoutColumn(const QVector<QLayoutItem *> &rowItems, int x, int y);
 };
 
 #endif // HORIZONTAL_FLOW_LAYOUT_H

--- a/cockatrice/src/client/ui/layouts/horizontal_flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/horizontal_flow_layout.h
@@ -1,0 +1,20 @@
+#ifndef HORIZONTAL_FLOW_LAYOUT_H
+#define HORIZONTAL_FLOW_LAYOUT_H
+
+#include "flow_layout.h"
+
+class HorizontalFlowLayout : public FlowLayout
+{
+public:
+    explicit HorizontalFlowLayout(QWidget *parent = nullptr);
+    ~HorizontalFlowLayout() override;
+
+    bool hasHeightForWidth() const override;
+    int heightForWidth(int width) const override;
+
+    void setGeometry(const QRect &rect) override;
+    int layoutRows(int originX, int originY, int availableWidth) override;
+    void layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y) override;
+};
+
+#endif // HORIZONTAL_FLOW_LAYOUT_H

--- a/cockatrice/src/client/ui/layouts/horizontal_flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/horizontal_flow_layout.h
@@ -13,8 +13,8 @@ public:
     int heightForWidth(int width) const override;
 
     void setGeometry(const QRect &rect) override;
-    int layoutColumns(int originX, int originY, int availableWidth);
-    void layoutColumn(const QVector<QLayoutItem *> &rowItems, int x, int y);
+    int layoutAllColumns(int originX, int originY, int availableWidth);
+    void layoutSingleColumn(const QVector<QLayoutItem *> &rowItems, int x, int y);
 };
 
 #endif // HORIZONTAL_FLOW_LAYOUT_H

--- a/cockatrice/src/client/ui/layouts/overlap_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/overlap_layout.cpp
@@ -300,3 +300,106 @@ void OverlapLayout::setMaxRows(int newValue)
 {
     maxRows = newValue;
 }
+
+/**
+ * @brief Calculates the maximum number of columns for a vertical overlap layout based on the current width.
+ *
+ * This function determines the maximum number of columns that can fit within the layout's width
+ * given the overlap percentage and item size, based on the current layout direction.
+ *
+ * @return Maximum number of columns that can fit within the layout width.
+ */
+int OverlapLayout::calculateMaxColumns() const
+{
+    if (direction != Qt::Vertical || itemList.isEmpty()) {
+        return 1; // Only relevant if the layout direction is vertical
+    }
+
+    // Determine maximum item width
+    int maxItemWidth = 0;
+    for (const QLayoutItem *item : itemList) {
+        if (item->widget()) {
+            QSize itemSize = item->widget()->sizeHint();
+            maxItemWidth = std::max(maxItemWidth, itemSize.width());
+        }
+    }
+
+    int availableWidth = parentWidget() ? parentWidget()->width() : 0;
+    // Determine the maximum number of columns that can fit
+    int columns = availableWidth / maxItemWidth;
+
+    return columns > 0 ? columns : 1;
+}
+
+/**
+ * @brief Calculates the maximum number of rows needed for a given number of columns in a vertical overlap layout.
+ *
+ * Determines how many rows are required to arrange all items given the calculated or specified number of columns.
+ *
+ * @param columns The number of columns available.
+ * @return The total number of rows required.
+ */
+int OverlapLayout::calculateRowsForColumns(int columns) const
+{
+    if (direction != Qt::Vertical || itemList.isEmpty() || columns <= 0) {
+        return 1; // Only relevant if the layout direction is vertical and there are items
+    }
+
+    int totalItems = itemList.size();
+    int rows = std::ceil(static_cast<double>(totalItems) / columns);
+
+    return rows;
+}
+
+/**
+ * @brief Calculates the maximum number of rows for a horizontal overlap layout based on the current height.
+ *
+ * This function determines the maximum number of rows that can fit within the layout's height
+ * given the overlap percentage and item size, based on the current layout direction.
+ *
+ * @return Maximum number of rows that can fit within the layout height.
+ */
+int OverlapLayout::calculateMaxRows() const
+{
+    if (direction != Qt::Horizontal || itemList.isEmpty()) {
+        return 1; // Only relevant if the layout direction is horizontal
+    }
+
+    // Determine maximum item height
+    int maxItemHeight = 0;
+    for (const QLayoutItem *item : itemList) {
+        if (item->widget()) {
+            QSize itemSize = item->widget()->sizeHint();
+            maxItemHeight = std::max(maxItemHeight, itemSize.height());
+        }
+    }
+
+    // Calculate the effective height of each item with the overlap applied
+    int overlapOffsetHeight = (maxItemHeight * (100 - overlapPercentage)) / 100;
+    int availableHeight = parentWidget() ? parentWidget()->height() : 0;
+
+    // Determine the maximum number of rows that can fit
+    int rows = availableHeight / overlapOffsetHeight;
+
+    return rows > 0 ? rows : 1;
+}
+
+/**
+ * @brief Calculates the maximum number of columns needed for a given number of rows in a horizontal overlap layout.
+ *
+ * Determines how many columns are required to arrange all items given the calculated or specified number of rows.
+ *
+ * @param rows The number of rows available.
+ * @return The total number of columns required.
+ */
+int OverlapLayout::calculateColumnsForRows(int rows) const
+{
+    if (direction != Qt::Horizontal || itemList.isEmpty() || rows <= 0) {
+        return 1; // Only relevant if the layout direction is horizontal and there are items
+    }
+
+    int totalItems = itemList.size();
+    int columns = std::ceil(static_cast<double>(totalItems) / rows);
+
+    return columns;
+}

--- a/cockatrice/src/client/ui/layouts/overlap_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/overlap_layout.cpp
@@ -153,37 +153,41 @@ void OverlapLayout::setGeometry(const QRect &rect)
     const int overlapOffsetWidth = (direction == Qt::Horizontal) ? (maxItemWidth * overlapPercentage / 100) : 0;
     const int overlapOffsetHeight = (direction == Qt::Vertical) ? (maxItemHeight * overlapPercentage / 100) : 0;
 
-    // Determine the number of columns and rows based on layout constraints and available space.
+    // Determine the number of columns based on layout constraints and available space.
+    int columns;
+    if (direction == Qt::Horizontal) {
+        if (maxColumns > 0) {
+            // Calculate the maximum possible columns given the available width and overlap.
+            const int availableColumns = (availableWidth + overlapOffsetWidth) /
+                                   (maxItemWidth - overlapOffsetWidth);
+            // Use the smaller of maxColumns and availableColumns.
+            columns = std::min(maxColumns, availableColumns);
+        } else {
+            // If no maxColumns constraint, allow as many columns as possible.
+            columns = INT_MAX;
+        }
+    } else {
+        // If not a horizontal layout, column count is irrelevant.
+        columns = INT_MAX;
+    }
 
-    const int columns =
-        (direction == Qt::Horizontal) // If the layout is horizontal,
-            ? (maxColumns > 0         // Check if a maximum column count is defined.
-                   ? std::min(maxColumns,
-                              (availableWidth + overlapOffsetWidth) /
-                                  (maxItemWidth -
-                                   overlapOffsetWidth)) // If defined,
-                                                        // Calculate the number of columns that can fit in the available
-                                                        // width, considering the item size and overlap. Use `std::min`
-                                                        // to ensure we do not exceed the maximum allowed columns.
-                   : INT_MAX) // If maxColumns is not defined (0 or negative), allow as many columns as possible.
-            : INT_MAX; // If the layout is not horizontal (likely vertical), set columns to an arbitrarily large number
-                       // (INT_MAX),
-    // because column count is not relevant in vertical layouts.
-
-    const int rows =
-        (direction == Qt::Vertical) // If the layout is vertical,
-            ? (maxRows > 0          // Check if a maximum row count is defined.
-                   ? std::min(
-                         maxRows,
-                         (availableHeight + overlapOffsetHeight) /
-                             (maxItemHeight -
-                              overlapOffsetHeight)) // If defined,
-                                                    // Calculate the number of rows that can fit in the available
-                                                    // height, considering the item size and overlap. Use `std::min` to
-                                                    // ensure we do not exceed the maximum allowed rows.
-                   : INT_MAX) // If maxRows is not defined (0 or negative), allow as many rows as possible.
-            : INT_MAX; // If the layout is not vertical (likely horizontal), set rows to an arbitrarily large number
-                       // (INT_MAX), because row count is not relevant in horizontal layouts.
+    // Determine the number of rows based on layout constraints and available space.
+    int rows;
+    if (direction == Qt::Vertical) {
+        if (maxRows > 0) {
+            // Calculate the maximum possible rows given the available height and overlap.
+            const int availableRows = (availableHeight + overlapOffsetHeight) /
+                                (maxItemHeight - overlapOffsetHeight);
+            // Use the smaller of maxRows and availableRows.
+            rows = std::min(maxRows, availableRows);
+        } else {
+            // If no maxRows constraint, allow as many rows as possible.
+            rows = INT_MAX;
+        }
+    } else {
+        // If not a vertical layout, row count is irrelevant.
+        rows = INT_MAX;
+    }
 
     // Initialize row and column indices.
     int currentRow = 0;

--- a/cockatrice/src/client/ui/layouts/overlap_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/overlap_layout.cpp
@@ -142,8 +142,8 @@ void OverlapLayout::setGeometry(const QRect &rect)
     for (const QLayoutItem *item : itemList) {
         if (item != nullptr && item->widget()) {
             QSize itemSize = item->widget()->sizeHint();
-            maxItemWidth = std::max(maxItemWidth, itemSize.width());
-            maxItemHeight = std::max(maxItemHeight, itemSize.height());
+            maxItemWidth = qMax(maxItemWidth, itemSize.width());
+            maxItemHeight = qMax(maxItemHeight, itemSize.height());
         }
     }
 
@@ -158,7 +158,7 @@ void OverlapLayout::setGeometry(const QRect &rect)
             // Calculate the maximum possible columns given the available width and overlap.
             const int availableColumns = (availableWidth + overlapOffsetWidth) / (maxItemWidth - overlapOffsetWidth);
             // Use the smaller of maxColumns and availableColumns.
-            columns = std::min(maxColumns, availableColumns);
+            columns = qMin(maxColumns, availableColumns);
         } else {
             // If no maxColumns constraint, allow as many columns as possible.
             columns = INT_MAX;
@@ -175,7 +175,7 @@ void OverlapLayout::setGeometry(const QRect &rect)
             // Calculate the maximum possible rows given the available height and overlap.
             const int availableRows = (availableHeight + overlapOffsetHeight) / (maxItemHeight - overlapOffsetHeight);
             // Use the smaller of maxRows and availableRows.
-            rows = std::min(maxRows, availableRows);
+            rows = qMin(maxRows, availableRows);
         } else {
             // If no maxRows constraint, allow as many rows as possible.
             rows = INT_MAX;
@@ -236,16 +236,16 @@ QSize OverlapLayout::calculatePreferredSize() const
         }
 
         QSize itemSize = item->widget()->sizeHint();
-        maxItemWidth = std::max(maxItemWidth, itemSize.width());
-        maxItemHeight = std::max(maxItemHeight, itemSize.height());
+        maxItemWidth = qMax(maxItemWidth, itemSize.width());
+        maxItemHeight = qMax(maxItemHeight, itemSize.height());
     }
 
     // Calculate the overlap offsets.
     const int extra_for_overlap = (100 - overlapPercentage);
     const int overlapOffsetWidth =
-        (direction == Qt::Horizontal) ? static_cast<int>(std::round((maxItemWidth / 100.0) * extra_for_overlap)) : 0;
+        (direction == Qt::Horizontal) ? qRound((maxItemWidth / 100.0) * extra_for_overlap) : 0;
     const int overlapOffsetHeight =
-        (direction == Qt::Vertical) ? static_cast<int>(std::round((maxItemHeight / 100.0) * extra_for_overlap)) : 0;
+        (direction == Qt::Vertical) ? qRound((maxItemHeight / 100.0) * extra_for_overlap) : 0;
 
     // Variables to hold the total dimensions based on layout orientation.
     int totalWidth = 0;
@@ -393,7 +393,7 @@ int OverlapLayout::calculateMaxColumns() const
         }
 
         QSize itemSize = item->widget()->sizeHint();
-        maxItemWidth = std::max(maxItemWidth, itemSize.width());
+        maxItemWidth = qMax(maxItemWidth, itemSize.width());
     }
 
     const int availableWidth = parentWidget() ? parentWidget()->width() : 0;
@@ -419,7 +419,7 @@ int OverlapLayout::calculateRowsForColumns(const int columns) const
 
     const int totalItems = static_cast<int>(itemList.size());
 
-    return std::ceil(static_cast<double>(totalItems) / columns);
+    return qCeil(totalItems / columns);
 }
 
 /**
@@ -444,7 +444,7 @@ int OverlapLayout::calculateMaxRows() const
         }
 
         QSize itemSize = item->widget()->sizeHint();
-        maxItemHeight = std::max(maxItemHeight, itemSize.height());
+        maxItemHeight = qMax(maxItemHeight, itemSize.height());
     }
 
     // Calculate the effective height of each item with the overlap applied
@@ -473,5 +473,5 @@ int OverlapLayout::calculateColumnsForRows(const int rows) const
 
     const int totalItems = static_cast<int>(itemList.size());
 
-    return std::ceil(static_cast<double>(totalItems) / rows);
+    return qCeil(totalItems / rows);
 }

--- a/cockatrice/src/client/ui/layouts/overlap_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/overlap_layout.cpp
@@ -140,12 +140,10 @@ void OverlapLayout::setGeometry(const QRect &rect)
     int maxItemWidth = 0;
     int maxItemHeight = 0;
     for (const QLayoutItem *item : itemList) {
-        if (item != nullptr) {
-            if (item->widget()) {
-                QSize itemSize = item->widget()->sizeHint();
-                maxItemWidth = std::max(maxItemWidth, itemSize.width());
-                maxItemHeight = std::max(maxItemHeight, itemSize.height());
-            }
+        if (item != nullptr && item->widget()) {
+            QSize itemSize = item->widget()->sizeHint();
+            maxItemWidth = std::max(maxItemWidth, itemSize.width());
+            maxItemHeight = std::max(maxItemHeight, itemSize.height());
         }
     }
 
@@ -390,10 +388,7 @@ int OverlapLayout::calculateMaxColumns() const
     // Determine maximum item width
     int maxItemWidth = 0;
     for (const QLayoutItem *item : itemList) {
-        if (item == nullptr) {
-            continue;
-        }
-        if (!item->widget()) {
+        if (item == nullptr || !item->widget()) {
             continue;
         }
 
@@ -444,10 +439,7 @@ int OverlapLayout::calculateMaxRows() const
     // Determine maximum item height
     int maxItemHeight = 0;
     for (const QLayoutItem *item : itemList) {
-        if (item == nullptr) {
-            continue;
-        }
-        if (!item->widget()) {
+        if (item == nullptr || !item->widget()) {
             continue;
         }
 

--- a/cockatrice/src/client/ui/layouts/overlap_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/overlap_layout.cpp
@@ -265,7 +265,10 @@ QSize OverlapLayout::calculatePreferredSize() const
         // Determine the number of rows:
         // - Use maxRows if maxColumns is set (to constrain the number of rows).
         // - Otherwise, assume a single row.
-        const int numRows = (maxColumns > 0) ? static_cast<int>(ceil(static_cast<double>(itemList.size()) / static_cast<double>(numColumns))) : 1;
+        const int numRows =
+            (maxColumns > 0)
+                ? static_cast<int>(ceil(static_cast<double>(itemList.size()) / static_cast<double>(numColumns)))
+                : 1;
 
         // Total height:
         // - Multiply the number of rows by the item height (maxItemHeight).
@@ -275,7 +278,9 @@ QSize OverlapLayout::calculatePreferredSize() const
         // Determine the number of columns:
         // - Use maxRows to calculate how many columns are needed if a row constraint exists.
         // - Otherwise, assume a single column.
-        const int numColumns = (maxRows != 0) ? static_cast<int>(ceil(static_cast<double>(itemList.size()) / static_cast<double>(maxRows))) : 1;
+        const int numColumns =
+            (maxRows != 0) ? static_cast<int>(ceil(static_cast<double>(itemList.size()) / static_cast<double>(maxRows)))
+                           : 1;
 
         // Total width:
         // - Multiply the number of columns by the item width (maxItemWidth).

--- a/cockatrice/src/client/ui/layouts/overlap_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/overlap_layout.cpp
@@ -1,0 +1,302 @@
+#include "overlap_layout.h"
+
+#include <QDebug>
+
+/**
+ * @class OverlapLayout
+ * @brief Custom layout class to arrange widgets with overlapping positions.
+ *
+ * The OverlapLayout class is a QLayout subclass that arranges child widgets
+ * in an overlapping configuration, allowing control over the overlap percentage
+ * and the number of rows or columns based on the chosen layout direction. This
+ * layout is particularly useful for visualizing elements that need to partially
+ * stack over one another, either horizontally or vertically.
+ */
+
+/**
+ * @brief Constructs an OverlapLayout with the specified parameters.
+ *
+ * Initializes a new OverlapLayout with the given overlap percentage, row or column limit,
+ * and layout direction. The overlap percentage determines how much each widget will
+ * overlap with the previous one. If maxColumns or maxRows are set to zero, it implies
+ * no limit in that respective dimension.
+ *
+ * @param overlapPercentage An integer representing the percentage of overlap between items (0-100).
+ * @param maxColumns The maximum number of columns allowed in the layout when in horizontal orientation (0 for unlimited).
+ * @param maxRows The maximum number of rows allowed in the layout when in vertical orientation (0 for unlimited).
+ * @param direction The orientation direction of the layout, either Qt::Horizontal or Qt::Vertical.
+ * @param parent The parent widget of this layout.
+ */
+OverlapLayout::OverlapLayout(int overlapPercentage,
+                             int maxColumns,
+                             int maxRows,
+                             Qt::Orientation direction,
+                             QWidget *parent)
+    : QLayout(parent), overlapPercentage(overlapPercentage), maxColumns(maxColumns), maxRows(maxRows),
+      direction(direction)
+{
+}
+
+/**
+ * @brief Destructor for OverlapLayout, ensuring cleanup of all layout items.
+ *
+ * Iterates through all layout items and deletes them. This prevents memory
+ * leaks by removing all child QLayoutItems stored in the layout.
+ */
+OverlapLayout::~OverlapLayout()
+{
+    QLayoutItem *item;
+    while ((item = OverlapLayout::takeAt(0))) {
+        delete item;
+    }
+}
+
+/**
+ * @brief Adds a new item to the layout.
+ *
+ * Appends a QLayoutItem to the internal list, allowing it to be positioned within the
+ * layout during the next geometry update. This method does not directly arrange the
+ * items; it merely adds them to the layout’s tracking.
+ *
+ * @param item Pointer to the QLayoutItem being added to this layout.
+ */
+void OverlapLayout::addItem(QLayoutItem *item)
+{
+    itemList.append(item);
+}
+
+/**
+ * @brief Retrieves the total count of items within the layout.
+ *
+ * Returns the number of items stored in the layout's internal item list.
+ * This count reflects how many widgets or spacers the layout is currently managing.
+ *
+ * @return Integer count of items in the layout.
+ */
+int OverlapLayout::count() const
+{
+    return itemList.size();
+}
+
+/**
+ * @brief Provides access to a layout item at a specified index.
+ *
+ * Allows retrieval of a QLayoutItem from the layout’s internal list
+ * by index. If the index is out of bounds, this function will return nullptr.
+ *
+ * @param index The index of the desired item.
+ * @return Pointer to the QLayoutItem at the specified index, or nullptr if index is invalid.
+ */
+QLayoutItem *OverlapLayout::itemAt(int index) const
+{
+    return itemList.value(index);
+}
+
+/**
+ * @brief Removes and returns a layout item at the specified index.
+ *
+ * Removes a QLayoutItem from the layout at the given index, reducing the layout's count.
+ * If the index is invalid, this function returns nullptr without any effect.
+ *
+ * @param index The index of the item to remove.
+ * @return Pointer to the removed QLayoutItem, or nullptr if index is invalid.
+ */
+QLayoutItem *OverlapLayout::takeAt(int index)
+{
+    if (index >= 0 && index < itemList.size()) {
+        return itemList.takeAt(index);
+    }
+    return nullptr;
+}
+
+/**
+ * @brief Sets the geometry for the layout items, arranging them with the specified overlap.
+ *
+ * Positions each QLayoutItem within the specified rectangle `rect`, respecting
+ * the layout’s direction, overlap percentage, and row/column limits. The method
+ * calculates the maximum allowable size for each item based on the parent widget’s dimensions.
+ * Items are then arranged with an offset based on the overlap percentage, either horizontally
+ * or vertically, depending on the layout direction. The geometry of each item is then set
+ * within the calculated bounds.
+ *
+ * @param rect The rectangle defining the area within which the layout should arrange items.
+ */
+void OverlapLayout::setGeometry(const QRect &rect)
+{
+    QLayout::setGeometry(rect);
+
+    if (itemList.isEmpty())
+        return;
+
+    QWidget *parentWidget = this->parentWidget();
+    if (parentWidget) {
+        int availableWidth = parentWidget->width();
+        int availableHeight = parentWidget->height();
+
+        QMargins margins = parentWidget->contentsMargins();
+        availableWidth -= margins.left() + margins.right();
+        availableHeight -= margins.top() + margins.bottom();
+
+        int maxItemWidth = 0;
+        int maxItemHeight = 0;
+
+        for (const QLayoutItem *item : itemList) {
+            if (item->widget()) {
+                QSize itemSize = item->widget()->sizeHint();
+                maxItemWidth = std::max(maxItemWidth, itemSize.width());
+                maxItemHeight = std::max(maxItemHeight, itemSize.height());
+            }
+        }
+
+        int overlapOffsetWidth = (direction == Qt::Horizontal) ? (maxItemWidth * overlapPercentage / 100) : 0;
+        int overlapOffsetHeight = (direction == Qt::Vertical) ? (maxItemHeight * overlapPercentage / 100) : 0;
+
+        int columns = (direction == Qt::Horizontal)
+                          ? (maxColumns > 0 ? std::min(maxColumns, (availableWidth + overlapOffsetWidth) /
+                                                                       (maxItemWidth - overlapOffsetWidth))
+                                            : INT_MAX)
+                          : INT_MAX;
+        int rows = (direction == Qt::Vertical)
+                       ? (maxRows > 0 ? std::min(maxRows, (availableHeight + overlapOffsetHeight) /
+                                                              (maxItemHeight - overlapOffsetHeight))
+                                      : INT_MAX)
+                       : INT_MAX;
+
+        int currentRow = 0;
+        int currentColumn = 0;
+
+        for (int i = 0; i < itemList.size(); ++i) {
+            QLayoutItem *item = itemList.at(i);
+            int xPos = rect.left() + currentColumn * (maxItemWidth - overlapOffsetWidth);
+            int yPos = rect.top() + currentRow * (maxItemHeight - overlapOffsetHeight);
+            item->setGeometry(QRect(xPos, yPos, maxItemWidth, maxItemHeight));
+
+            if (direction == Qt::Horizontal) {
+                currentColumn++;
+                if (currentColumn >= columns) {
+                    currentColumn = 0;
+                    currentRow++;
+                }
+            } else {
+                currentRow++;
+                if (currentRow >= rows) {
+                    currentRow = 0;
+                    currentColumn++;
+                }
+            }
+        }
+    }
+}
+
+/**
+ * @brief Calculates the preferred size for the layout, considering overlap and orientation.
+ *
+ * Determines an optimal size for the layout by calculating the area needed to arrange all
+ * items with the desired overlap. This calculation considers the number of rows/columns,
+ * item size, overlap offset, and the layout's direction. Useful for setting a size hint
+ * when the layout is used within other widgets.
+ *
+ * @return The preferred layout size as a QSize object.
+ */
+QSize OverlapLayout::calculatePreferredSize() const
+{
+    QSize preferredSize(0, 0);
+
+    int maxItemWidth = 0;
+    int maxItemHeight = 0;
+
+    for (const QLayoutItem *item : itemList) {
+        if (item->widget()) {
+            QSize itemSize = item->widget()->sizeHint();
+            maxItemWidth = std::max(maxItemWidth, itemSize.width());
+            maxItemHeight = std::max(maxItemHeight, itemSize.height());
+        }
+    }
+
+    int extra_for_overlap = (100 - overlapPercentage);
+    int overlapOffsetWidth =
+        (direction == Qt::Horizontal) ? static_cast<int>(std::round((maxItemWidth / 100.0) * extra_for_overlap)) : 0;
+    int overlapOffsetHeight =
+        (direction == Qt::Vertical) ? static_cast<int>(std::round((maxItemHeight / 100.0) * extra_for_overlap)) : 0;
+
+    int totalWidth = 0;
+    int totalHeight = 0;
+
+    if (direction == Qt::Horizontal) {
+        int numColumns = (maxColumns > 0) ? maxColumns : itemList.size();
+        int extra_space_for_overlaps = overlapOffsetWidth * (numColumns - 1);
+        totalWidth = maxItemWidth + extra_space_for_overlaps;
+
+        int numRows = (maxColumns > 0) ? ceil(itemList.size() / static_cast<double>(maxRows)) : 1;
+        totalHeight = maxItemHeight * numRows - (numRows - 1) * overlapOffsetHeight;
+    } else if (direction == Qt::Vertical) {
+        int numColumns = (maxRows != 0) ? ceil(itemList.size() / static_cast<double>(maxRows)) : 1;
+        totalWidth = maxItemWidth * numColumns - (numColumns - 1) * overlapOffsetWidth;
+
+        int numRows = (maxRows > 0) ? maxRows : itemList.size();
+        int extra_space_for_overlaps = overlapOffsetHeight * (numRows - 1);
+        totalHeight = maxItemHeight + extra_space_for_overlaps;
+    }
+
+    preferredSize = QSize(totalWidth, totalHeight);
+
+    return preferredSize;
+}
+
+/**
+ * @brief Returns the size hint for the layout, based on preferred size calculations.
+ *
+ * Provides a recommended size for the layout, useful for layouts that need to fit within
+ * a specific parent container size. This takes into account the preferred size and
+ * any specific item size requirements.
+ *
+ * @return The layout's recommended QSize.
+ */
+QSize OverlapLayout::sizeHint() const
+{
+    return calculatePreferredSize();
+}
+
+/**
+ * @brief Provides the minimum size hint for the layout, ensuring functionality within constraints.
+ *
+ * Defines a minimum workable size for the layout to prevent excessive compression
+ * that could distort item arrangement.
+ *
+ * @return The minimum QSize for this layout.
+ */
+QSize OverlapLayout::minimumSize() const
+{
+    return calculatePreferredSize();
+}
+
+
+/**
+ * @brief Sets the layout's orientation direction.
+ *
+ * @param new_direction The new orientation direction (Qt::Horizontal or Qt::Vertical).
+ */
+void OverlapLayout::setDirection(Qt::Orientation new_direction)
+{
+    direction = new_direction;
+}
+
+/**
+ * @brief Sets the maximum number of columns for horizontal orientation.
+ *
+ * @param newValue New maximum column count.
+ */
+void OverlapLayout::setMaxColumns(int newValue)
+{
+    maxColumns = newValue;
+}
+
+/**
+ * @brief Sets the maximum number of rows for vertical orientation.
+ *
+ * @param newValue New maximum row count.
+ */
+void OverlapLayout::setMaxRows(int newValue)
+{
+    maxRows = newValue;
+}

--- a/cockatrice/src/client/ui/layouts/overlap_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/overlap_layout.cpp
@@ -158,8 +158,7 @@ void OverlapLayout::setGeometry(const QRect &rect)
     if (direction == Qt::Horizontal) {
         if (maxColumns > 0) {
             // Calculate the maximum possible columns given the available width and overlap.
-            const int availableColumns = (availableWidth + overlapOffsetWidth) /
-                                   (maxItemWidth - overlapOffsetWidth);
+            const int availableColumns = (availableWidth + overlapOffsetWidth) / (maxItemWidth - overlapOffsetWidth);
             // Use the smaller of maxColumns and availableColumns.
             columns = std::min(maxColumns, availableColumns);
         } else {
@@ -176,8 +175,7 @@ void OverlapLayout::setGeometry(const QRect &rect)
     if (direction == Qt::Vertical) {
         if (maxRows > 0) {
             // Calculate the maximum possible rows given the available height and overlap.
-            const int availableRows = (availableHeight + overlapOffsetHeight) /
-                                (maxItemHeight - overlapOffsetHeight);
+            const int availableRows = (availableHeight + overlapOffsetHeight) / (maxItemHeight - overlapOffsetHeight);
             // Use the smaller of maxRows and availableRows.
             rows = std::min(maxRows, availableRows);
         } else {

--- a/cockatrice/src/client/ui/layouts/overlap_layout.h
+++ b/cockatrice/src/client/ui/layouts/overlap_layout.h
@@ -1,0 +1,36 @@
+#ifndef OVERLAP_LAYOUT_H
+#define OVERLAP_LAYOUT_H
+
+#include <QLayout>
+#include <QList>
+#include <QWidget>
+
+
+class OverlapLayout : public QLayout {
+public:
+    OverlapLayout(int overlapPercentage = 10, int maxColumns = 2, int maxRows = 2, Qt::Orientation direction = Qt::Horizontal, QWidget* parent = nullptr);
+    ~OverlapLayout();
+
+    void addItem(QLayoutItem* item) override;
+    int count() const override;
+    QLayoutItem* itemAt(int index) const override;
+    QLayoutItem* takeAt(int index) override;
+    void setGeometry(const QRect& rect) override;
+    QSize minimumSize() const override;
+    QSize sizeHint() const override;
+    void setMaxColumns(int newValue);
+    void setMaxRows(int newValue);
+    void setDirection(Qt::Orientation direction);
+
+private:
+    QList<QLayoutItem*> itemList;
+    int overlapPercentage;
+    int maxColumns;
+    int maxRows;
+    Qt::Orientation direction;
+
+    // Calculate the preferred size of the layout
+    QSize calculatePreferredSize() const;
+};
+
+#endif // OVERLAP_LAYOUT_H

--- a/cockatrice/src/client/ui/layouts/overlap_layout.h
+++ b/cockatrice/src/client/ui/layouts/overlap_layout.h
@@ -5,17 +5,21 @@
 #include <QList>
 #include <QWidget>
 
-
-class OverlapLayout : public QLayout {
+class OverlapLayout : public QLayout
+{
 public:
-    OverlapLayout(int overlapPercentage = 10, int maxColumns = 2, int maxRows = 2, Qt::Orientation direction = Qt::Horizontal, QWidget* parent = nullptr);
+    OverlapLayout(QWidget *parent = nullptr,
+                  int overlapPercentage = 10,
+                  int maxColumns = 2,
+                  int maxRows = 2,
+                  Qt::Orientation direction = Qt::Horizontal);
     ~OverlapLayout();
 
-    void addItem(QLayoutItem* item) override;
+    void addItem(QLayoutItem *item) override;
     int count() const override;
-    QLayoutItem* itemAt(int index) const override;
-    QLayoutItem* takeAt(int index) override;
-    void setGeometry(const QRect& rect) override;
+    QLayoutItem *itemAt(int index) const override;
+    QLayoutItem *takeAt(int index) override;
+    void setGeometry(const QRect &rect) override;
     QSize minimumSize() const override;
     QSize sizeHint() const override;
     void setMaxColumns(int newValue);
@@ -27,7 +31,7 @@ public:
     void setDirection(Qt::Orientation direction);
 
 private:
-    QList<QLayoutItem*> itemList;
+    QList<QLayoutItem *> itemList;
     int overlapPercentage;
     int maxColumns;
     int maxRows;

--- a/cockatrice/src/client/ui/layouts/overlap_layout.h
+++ b/cockatrice/src/client/ui/layouts/overlap_layout.h
@@ -20,6 +20,10 @@ public:
     QSize sizeHint() const override;
     void setMaxColumns(int newValue);
     void setMaxRows(int newValue);
+    int calculateMaxColumns() const;
+    int calculateRowsForColumns(int columns) const;
+    int calculateMaxRows() const;
+    int calculateColumnsForRows(int rows) const;
     void setDirection(Qt::Orientation direction);
 
 private:

--- a/cockatrice/src/client/ui/layouts/overlap_layout.h
+++ b/cockatrice/src/client/ui/layouts/overlap_layout.h
@@ -22,13 +22,13 @@ public:
     void setGeometry(const QRect &rect) override;
     QSize minimumSize() const override;
     QSize sizeHint() const override;
-    void setMaxColumns(int newValue);
-    void setMaxRows(int newValue);
+    void setMaxColumns(int _maxColumns);
+    void setMaxRows(int _maxRows);
     int calculateMaxColumns() const;
     int calculateRowsForColumns(int columns) const;
     int calculateMaxRows() const;
     int calculateColumnsForRows(int rows) const;
-    void setDirection(Qt::Orientation direction);
+    void setDirection(Qt::Orientation _direction);
 
 private:
     QList<QLayoutItem *> itemList;

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
@@ -127,16 +127,18 @@ int VerticalFlowLayout::layoutAllRows(const int originX, const int originY, cons
 void VerticalFlowLayout::layoutSingleRow(const QVector<QLayoutItem *> &rowItems, int x, const int y)
 {
     for (QLayoutItem *item : rowItems) {
-        if (!(item == nullptr || item->isEmpty())) {
-            // Get the maximum allowed size for the item
-            QSize itemMaxSize = item->widget()->maximumSize();
-            // Constrain the item's width and height to its size hint or maximum size
-            const int itemWidth = qMin(item->sizeHint().width(), itemMaxSize.width());
-            const int itemHeight = qMin(item->sizeHint().height(), itemMaxSize.height());
-            // Set the item's geometry based on the computed size and position
-            item->setGeometry(QRect(QPoint(x, y), QSize(itemWidth, itemHeight)));
-            // Move the x-position to the right, leaving space for horizontal spacing
-            x += itemWidth + horizontalSpacing();
+        if (item == nullptr || item->isEmpty()) {
+            continue;
         }
+
+        // Get the maximum allowed size for the item
+        QSize itemMaxSize = item->widget()->maximumSize();
+        // Constrain the item's width and height to its size hint or maximum size
+        const int itemWidth = qMin(item->sizeHint().width(), itemMaxSize.width());
+        const int itemHeight = qMin(item->sizeHint().height(), itemMaxSize.height());
+        // Set the item's geometry based on the computed size and position
+        item->setGeometry(QRect(QPoint(x, y), QSize(itemWidth, itemHeight)));
+        // Move the x-position to the right, leaving space for horizontal spacing
+        x += itemWidth + horizontalSpacing();
     }
 }

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
@@ -8,7 +8,7 @@
  * @param hSpacing The horizontal spacing between items.
  * @param vSpacing The vertical spacing between items.
  */
-VerticalFlowLayout::VerticalFlowLayout(QWidget *parent, int margin, int hSpacing, int vSpacing)
+VerticalFlowLayout::VerticalFlowLayout(QWidget *parent, const int margin, const int hSpacing, const int vSpacing)
     : FlowLayout(parent, margin, hSpacing, vSpacing)
 {
 }
@@ -30,23 +30,25 @@ VerticalFlowLayout::~VerticalFlowLayout()
  * @param width The available width for arranging layout items.
  * @return The total height required to fit all items, organized in rows constrained by the given width.
  */
-int VerticalFlowLayout::heightForWidth(int width) const
+int VerticalFlowLayout::heightForWidth(const int width) const
 {
     int height = 0;
     int rowWidth = 0;
     int rowHeight = 0;
 
-    for (QLayoutItem *item : items) {
-        if (!(item == nullptr || item->isEmpty())) {
-            int itemWidth = item->sizeHint().width() + horizontalSpacing();
-            if (rowWidth + itemWidth > width) {
-                height += rowHeight + verticalSpacing();
-                rowWidth = itemWidth;
-                rowHeight = item->sizeHint().height();
-            } else {
-                rowWidth += itemWidth;
-                rowHeight = qMax(rowHeight, item->sizeHint().height());
-            }
+    for (const QLayoutItem *item : items) {
+        if (item == nullptr || item->isEmpty()) {
+            continue;
+        }
+
+        int itemWidth = item->sizeHint().width() + horizontalSpacing();
+        if (rowWidth + itemWidth > width) {
+            height += rowHeight + verticalSpacing();
+            rowWidth = itemWidth;
+            rowHeight = item->sizeHint().height();
+        } else {
+            rowWidth += itemWidth;
+            rowHeight = qMax(rowHeight, item->sizeHint().height());
         }
     }
     height += rowHeight; // Add height of the last row
@@ -60,12 +62,11 @@ int VerticalFlowLayout::heightForWidth(int width) const
 void VerticalFlowLayout::setGeometry(const QRect &rect)
 {
     // If we have a parent scroll area, we're clamped to that, else we use our own rectangle.
-    int availableWidth = getParentScrollAreaWidth() == 0 ? rect.width() : getParentScrollAreaWidth();
+    const int availableWidth = getParentScrollAreaWidth() == 0 ? rect.width() : getParentScrollAreaWidth();
 
-    int totalHeight = layoutAllRows(rect.x(), rect.y(), availableWidth);
+    const int totalHeight = layoutAllRows(rect.x(), rect.y(), availableWidth);
 
-    QWidget *parentWidgetPtr = parentWidget();
-    if (parentWidgetPtr) {
+    if (QWidget *parentWidgetPtr = parentWidget()) {
         parentWidgetPtr->setMinimumSize(availableWidth, totalHeight);
     }
 }
@@ -78,7 +79,7 @@ void VerticalFlowLayout::setGeometry(const QRect &rect)
  * @param availableWidth The width within which each row is constrained.
  * @return The total height after arranging all rows.
  */
-int VerticalFlowLayout::layoutAllRows(int originX, int originY, int availableWidth)
+int VerticalFlowLayout::layoutAllRows(const int originX, const int originY, const int availableWidth)
 {
     QVector<QLayoutItem *> rowItems; // Holds items for the current row
     int currentXPosition = originX;  // Tracks the x-coordinate while placing items
@@ -87,6 +88,10 @@ int VerticalFlowLayout::layoutAllRows(int originX, int originY, int availableWid
     int rowHeight = 0; // Tracks the maximum height of items in the current row
 
     for (QLayoutItem *item : items) {
+        if (item == nullptr || item->isEmpty()) {
+            continue;
+        }
+
         QSize itemSize = item->sizeHint();                      // The suggested size for the current item
         int itemWidth = itemSize.width() + horizontalSpacing(); // Item width plus spacing
 
@@ -119,15 +124,15 @@ int VerticalFlowLayout::layoutAllRows(int originX, int originY, int availableWid
  * @param x The starting x-coordinate for the row.
  * @param y The starting y-coordinate for the row.
  */
-void VerticalFlowLayout::layoutSingleRow(const QVector<QLayoutItem *> &rowItems, int x, int y)
+void VerticalFlowLayout::layoutSingleRow(const QVector<QLayoutItem *> &rowItems, int x, const int y)
 {
     for (QLayoutItem *item : rowItems) {
         if (!(item == nullptr || item->isEmpty())) {
             // Get the maximum allowed size for the item
             QSize itemMaxSize = item->widget()->maximumSize();
             // Constrain the item's width and height to its size hint or maximum size
-            int itemWidth = qMin(item->sizeHint().width(), itemMaxSize.width());
-            int itemHeight = qMin(item->sizeHint().height(), itemMaxSize.height());
+            const int itemWidth = qMin(item->sizeHint().width(), itemMaxSize.width());
+            const int itemHeight = qMin(item->sizeHint().height(), itemMaxSize.height());
             // Set the item's geometry based on the computed size and position
             item->setGeometry(QRect(QPoint(x, y), QSize(itemWidth, itemHeight)));
             // Move the x-position to the right, leaving space for horizontal spacing

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
@@ -4,8 +4,12 @@
  * @brief Constructs a VerticalFlowLayout instance with the specified parent widget.
  *        This layout arranges items in rows within the given width, automatically adjusting its height.
  * @param parent The parent widget to which this layout belongs.
+ * @param margin The layout margin.
+ * @param hSpacing The horizontal spacing between items.
+ * @param vSpacing The vertical spacing between items.
  */
-VerticalFlowLayout::VerticalFlowLayout(QWidget *parent) : FlowLayout(parent)
+VerticalFlowLayout::VerticalFlowLayout(QWidget *parent, int margin, int hSpacing, int vSpacing)
+    : FlowLayout(parent, margin, hSpacing, vSpacing)
 {
 }
 
@@ -42,9 +46,9 @@ int VerticalFlowLayout::heightForWidth(int width) const
     int rowHeight = 0;
 
     for (QLayoutItem *item : items) {
-        int itemWidth = item->sizeHint().width();
+        int itemWidth = item->sizeHint().width() + horizontalSpacing();
         if (rowWidth + itemWidth > width) {
-            height += rowHeight;
+            height += rowHeight + verticalSpacing();
             rowWidth = itemWidth;
             rowHeight = item->sizeHint().height();
         } else {
@@ -92,18 +96,21 @@ int VerticalFlowLayout::layoutRows(int originX, int originY, int availableWidth)
 
     for (QLayoutItem *item : items) {
         QSize itemSize = item->sizeHint();
-        if (currentXPosition + itemSize.width() > availableWidth) {
+        int itemWidth = itemSize.width() + horizontalSpacing();
+
+        if (currentXPosition + itemWidth > availableWidth) {
             layoutRow(rowItems, originX, currentYPosition);
             rowItems.clear();
             currentXPosition = originX;
-            currentYPosition += rowHeight;
+            currentYPosition += rowHeight + verticalSpacing();
             rowWidth = 0;
             rowHeight = 0;
         }
+
         rowItems.append(item);
-        rowWidth += itemSize.width();
+        rowWidth += itemWidth;
         rowHeight = qMax(rowHeight, itemSize.height());
-        currentXPosition += itemSize.width();
+        currentXPosition += itemWidth;
     }
 
     layoutRow(rowItems, originX, currentYPosition);
@@ -124,6 +131,6 @@ void VerticalFlowLayout::layoutRow(const QVector<QLayoutItem *> &rowItems, int x
         int itemWidth = qMin(item->sizeHint().width(), itemMaxSize.width());
         int itemHeight = qMin(item->sizeHint().height(), itemMaxSize.height());
         item->setGeometry(QRect(QPoint(x, y), QSize(itemWidth, itemHeight)));
-        x += itemWidth;
+        x += itemWidth + horizontalSpacing(); // Include horizontal spacing between items
     }
 }

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
@@ -138,4 +138,3 @@ void VerticalFlowLayout::layoutSingleRow(const QVector<QLayoutItem *> &rowItems,
         }
     }
 }
-

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
@@ -108,9 +108,9 @@ int VerticalFlowLayout::layoutRows(int originX, int originY, int availableWidth)
         }
 
         rowItems.append(item);
-        rowWidth += itemWidth;
+        rowWidth += itemWidth + horizontalSpacing();
         rowHeight = qMax(rowHeight, itemSize.height());
-        currentXPosition += itemWidth;
+        currentXPosition += itemWidth + horizontalSpacing();
     }
 
     layoutRow(rowItems, originX, currentYPosition);

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
@@ -1,0 +1,128 @@
+#include "vertical_flow_layout.h"
+
+/**
+ * @brief Constructs a VerticalFlowLayout instance with the specified parent widget.
+ *        This layout arranges items in rows within the given width, automatically adjusting its height.
+ * @param parent The parent widget to which this layout belongs.
+ */
+VerticalFlowLayout::VerticalFlowLayout(QWidget *parent) : FlowLayout(parent)
+{
+}
+
+/**
+ * @brief Destructor for VerticalFlowLayout, responsible for cleaning up layout items.
+ */
+VerticalFlowLayout::~VerticalFlowLayout()
+{
+    QLayoutItem *item;
+    while ((item = FlowLayout::takeAt(0))) {
+        delete item;
+    }
+}
+
+/**
+ * @brief Indicates that the layout has a variable height based on its width.
+ * @return True, as the layout adjusts its height according to the available width.
+ */
+bool VerticalFlowLayout::hasHeightForWidth() const
+{
+    return true;
+}
+
+/**
+ * @brief Calculates the required height to display all items, given a specified width.
+ *        This method arranges items into rows and determines the total height needed.
+ * @param width The available width for arranging layout items.
+ * @return The total height required to fit all items, organized in rows constrained by the given width.
+ */
+int VerticalFlowLayout::heightForWidth(int width) const
+{
+    int height = 0;
+    int rowWidth = 0;
+    int rowHeight = 0;
+
+    for (QLayoutItem *item : items) {
+        int itemWidth = item->sizeHint().width();
+        if (rowWidth + itemWidth > width) {
+            height += rowHeight;
+            rowWidth = itemWidth;
+            rowHeight = item->sizeHint().height();
+        } else {
+            rowWidth += itemWidth;
+            rowHeight = qMax(rowHeight, item->sizeHint().height());
+        }
+    }
+    height += rowHeight; // Add height of the last row
+    return height;
+}
+
+/**
+ * @brief Sets the geometry of the layout items, arranging them in rows within the given width.
+ * @param rect The rectangle area defining the layout space.
+ */
+void VerticalFlowLayout::setGeometry(const QRect &rect)
+{
+    int availableWidth = qMax(rect.width(), getParentScrollAreaWidth());
+
+    int totalHeight = layoutRows(rect.x(), rect.y(), availableWidth);
+
+    QWidget *parentWidgetPtr = parentWidget();
+    if (parentWidgetPtr) {
+        parentWidgetPtr->setMinimumSize(availableWidth, totalHeight);
+    }
+}
+
+/**
+ * @brief Lays out items into rows according to the available width, starting from a given origin.
+ *        Each row is arranged within `availableWidth`, wrapping to a new row as necessary.
+ * @param originX The x-coordinate for the layout start position.
+ * @param originY The y-coordinate for the layout start position.
+ * @param availableWidth The width within which each row is constrained.
+ * @return The total height after arranging all rows.
+ */
+int VerticalFlowLayout::layoutRows(int originX, int originY, int availableWidth)
+{
+    QVector<QLayoutItem *> rowItems;
+    int currentXPosition = originX;
+    int currentYPosition = originY;
+
+    int rowWidth = 0;
+    int rowHeight = 0;
+
+    for (QLayoutItem *item : items) {
+        QSize itemSize = item->sizeHint();
+        if (currentXPosition + itemSize.width() > availableWidth) {
+            layoutRow(rowItems, originX, currentYPosition);
+            rowItems.clear();
+            currentXPosition = originX;
+            currentYPosition += rowHeight;
+            rowWidth = 0;
+            rowHeight = 0;
+        }
+        rowItems.append(item);
+        rowWidth += itemSize.width();
+        rowHeight = qMax(rowHeight, itemSize.height());
+        currentXPosition += itemSize.width();
+    }
+
+    layoutRow(rowItems, originX, currentYPosition);
+
+    return currentYPosition + rowHeight;
+}
+
+/**
+ * @brief Arranges a single row of items within specified x and y starting positions.
+ * @param rowItems A list of items to be arranged in the row.
+ * @param x The starting x-coordinate for the row.
+ * @param y The starting y-coordinate for the row.
+ */
+void VerticalFlowLayout::layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y)
+{
+    for (QLayoutItem *item : rowItems) {
+        QSize itemMaxSize = item->widget()->maximumSize();
+        int itemWidth = qMin(item->sizeHint().width(), itemMaxSize.width());
+        int itemHeight = qMin(item->sizeHint().height(), itemMaxSize.height());
+        item->setGeometry(QRect(QPoint(x, y), QSize(itemWidth, itemHeight)));
+        x += itemWidth;
+    }
+}

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
@@ -62,7 +62,8 @@ int VerticalFlowLayout::heightForWidth(int width) const
  */
 void VerticalFlowLayout::setGeometry(const QRect &rect)
 {
-    int availableWidth = qMax(rect.width(), getParentScrollAreaWidth());
+    // If we have a parent scroll area, we're clamped to that, else we use our own rectangle.
+    int availableWidth = getParentScrollAreaWidth() == 0 ? rect.width() : getParentScrollAreaWidth();
 
     int totalHeight = layoutRows(rect.x(), rect.y(), availableWidth);
 

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.cpp
@@ -84,7 +84,6 @@ int VerticalFlowLayout::layoutAllRows(int originX, int originY, int availableWid
     int currentXPosition = originX;  // Tracks the x-coordinate while placing items
     int currentYPosition = originY;  // Tracks the y-coordinate, moving down after each row
 
-    int rowWidth = 0;  // Tracks the cumulative width of items in the current row
     int rowHeight = 0; // Tracks the maximum height of items in the current row
 
     for (QLayoutItem *item : items) {
@@ -98,13 +97,11 @@ int VerticalFlowLayout::layoutAllRows(int originX, int originY, int availableWid
             rowItems.clear();                                  // Reset the list for the new row
             currentXPosition = originX;                        // Reset x-position to the row's start
             currentYPosition += rowHeight + verticalSpacing(); // Move y-position down to the next row
-            rowWidth = 0;                                      // Reset row width for the new row
             rowHeight = 0;                                     // Reset row height for the new row
         }
 
         // Add the item to the current row
         rowItems.append(item);
-        rowWidth += itemWidth + horizontalSpacing();         // Accumulate the row's total width
         rowHeight = qMax(rowHeight, itemSize.height());      // Update the row's height to the tallest item
         currentXPosition += itemWidth + horizontalSpacing(); // Move x-position for the next item
     }

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.h
@@ -9,7 +9,6 @@ public:
     explicit VerticalFlowLayout(QWidget *parent = nullptr, int margin = 0, int hSpacing = 0, int vSpacing = 0);
     ~VerticalFlowLayout() override;
 
-    bool hasHeightForWidth() const override;
     int heightForWidth(int width) const override;
 
     void setGeometry(const QRect &rect) override;

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.h
@@ -9,7 +9,7 @@ public:
     explicit VerticalFlowLayout(QWidget *parent = nullptr, int margin = 0, int hSpacing = 0, int vSpacing = 0);
     ~VerticalFlowLayout() override;
 
-    int heightForWidth(int width) const override;
+    [[nodiscard]] int heightForWidth(int width) const override;
 
     void setGeometry(const QRect &rect) override;
     int layoutAllRows(int originX, int originY, int availableWidth) override;

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.h
@@ -6,15 +6,15 @@
 class VerticalFlowLayout : public FlowLayout
 {
 public:
-    explicit VerticalFlowLayout(QWidget *parent = nullptr);
+    explicit VerticalFlowLayout(QWidget *parent = nullptr, int margin = 0, int hSpacing = 0, int vSpacing = 0);
     ~VerticalFlowLayout() override;
 
     bool hasHeightForWidth() const override;
     int heightForWidth(int width) const override;
 
     void setGeometry(const QRect &rect) override;
-    int layoutRows(int originX, int originY, int availableWidth) override;
-    void layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y) override;
+    int layoutRows(int originX, int originY, int availableWidth);
+    void layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y);
 };
 
 #endif // VERTICAL_FLOW_LAYOUT_H

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.h
@@ -1,0 +1,20 @@
+#ifndef VERTICAL_FLOW_LAYOUT_H
+#define VERTICAL_FLOW_LAYOUT_H
+
+#include "flow_layout.h"
+
+class VerticalFlowLayout : public FlowLayout
+{
+public:
+    explicit VerticalFlowLayout(QWidget *parent = nullptr);
+    ~VerticalFlowLayout() override;
+
+    bool hasHeightForWidth() const override;
+    int heightForWidth(int width) const override;
+
+    void setGeometry(const QRect &rect) override;
+    int layoutRows(int originX, int originY, int availableWidth) override;
+    void layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y) override;
+};
+
+#endif // VERTICAL_FLOW_LAYOUT_H

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.h
@@ -13,8 +13,8 @@ public:
     int heightForWidth(int width) const override;
 
     void setGeometry(const QRect &rect) override;
-    int layoutRows(int originX, int originY, int availableWidth);
-    void layoutRow(const QVector<QLayoutItem *> &rowItems, int x, int y);
+    int layoutAllRows(int originX, int originY, int availableWidth);
+    void layoutSingleRow(const QVector<QLayoutItem *> &rowItems, int x, int y);
 };
 
 #endif // VERTICAL_FLOW_LAYOUT_H

--- a/cockatrice/src/client/ui/layouts/vertical_flow_layout.h
+++ b/cockatrice/src/client/ui/layouts/vertical_flow_layout.h
@@ -12,8 +12,8 @@ public:
     int heightForWidth(int width) const override;
 
     void setGeometry(const QRect &rect) override;
-    int layoutAllRows(int originX, int originY, int availableWidth);
-    void layoutSingleRow(const QVector<QLayoutItem *> &rowItems, int x, int y);
+    int layoutAllRows(int originX, int originY, int availableWidth) override;
+    void layoutSingleRow(const QVector<QLayoutItem *> &rowItems, int x, int y) override;
 };
 
 #endif // VERTICAL_FLOW_LAYOUT_H

--- a/cockatrice/src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/cards/card_info_picture_with_text_overlay_widget.cpp
@@ -66,7 +66,7 @@ void CardInfoPictureWithTextOverlayWidget::setOutlineColor(const QColor &color)
  */
 void CardInfoPictureWithTextOverlayWidget::setFontSize(const int size)
 {
-    fontSize = size;
+    fontSize = size > 0 ? size : 1;
     update();
 }
 
@@ -109,48 +109,50 @@ void CardInfoPictureWithTextOverlayWidget::paintEvent(QPaintEvent *event)
 
     // Get the pixmap from the base class using the getter
     const QPixmap &pixmap = getResizedPixmap();
-    if (!pixmap.isNull()) {
-        // Calculate size and position for drawing
-        const QSize scaledSize = pixmap.size().scaled(size(), Qt::KeepAspectRatio);
-        const QPoint topLeft{(width() - scaledSize.width()) / 2, (height() - scaledSize.height()) / 2};
-        const QRect pixmapRect(topLeft, scaledSize);
-
-        // Prepare text wrapping
-        const QFontMetrics fontMetrics(font);
-        const int lineHeight = fontMetrics.height();
-        const int textWidth = pixmapRect.width();
-        QString wrappedText;
-
-        // Break the text into multiple lines to fit within the pixmap width
-        QString currentLine;
-        QStringList words = overlayText.split(' ');
-        for (const QString &word : words) {
-            if (fontMetrics.horizontalAdvance(currentLine + " " + word) > textWidth) {
-                wrappedText += currentLine + '\n';
-                currentLine = word;
-            } else {
-                if (!currentLine.isEmpty()) {
-                    currentLine += " ";
-                }
-                currentLine += word;
-            }
-        }
-        wrappedText += currentLine;
-
-        // Calculate total text block height
-        const int totalTextHeight = static_cast<int>(wrappedText.count('\n')) * lineHeight + lineHeight;
-
-        // Set up the text layout options
-        QTextOption textOption;
-        textOption.setAlignment(textAlignment);
-
-        // Create a text rectangle centered within the pixmap rect
-        auto textRect = QRect(pixmapRect.left(), pixmapRect.top(), pixmapRect.width(), totalTextHeight);
-        textRect.moveTop((pixmapRect.height() - totalTextHeight) / 2 + pixmapRect.top());
-
-        // Draw the outlined text
-        drawOutlinedText(painter, textRect, wrappedText, textOption);
+    if (pixmap.isNull()) {
+        return;
     }
+
+    // Calculate size and position for drawing
+    const QSize scaledSize = pixmap.size().scaled(size(), Qt::KeepAspectRatio);
+    const QPoint topLeft{(width() - scaledSize.width()) / 2, (height() - scaledSize.height()) / 2};
+    const QRect pixmapRect(topLeft, scaledSize);
+
+    // Prepare text wrapping
+    const QFontMetrics fontMetrics(font);
+    const int lineHeight = fontMetrics.height();
+    const int textWidth = pixmapRect.width();
+    QString wrappedText;
+
+    // Break the text into multiple lines to fit within the pixmap width
+    QString currentLine;
+    QStringList words = overlayText.split(' ');
+    for (const QString &word : words) {
+        if (fontMetrics.horizontalAdvance(currentLine + " " + word) > textWidth) {
+            wrappedText += currentLine + '\n';
+            currentLine = word;
+        } else {
+            if (!currentLine.isEmpty()) {
+                currentLine += " ";
+            }
+            currentLine += word;
+        }
+    }
+    wrappedText += currentLine;
+
+    // Calculate total text block height
+    const int totalTextHeight = static_cast<int>(wrappedText.count('\n')) * lineHeight + lineHeight;
+
+    // Set up the text layout options
+    QTextOption textOption;
+    textOption.setAlignment(textAlignment);
+
+    // Create a text rectangle centered within the pixmap rect
+    auto textRect = QRect(pixmapRect.left(), pixmapRect.top(), pixmapRect.width(), totalTextHeight);
+    textRect.moveTop((pixmapRect.height() - totalTextHeight) / 2 + pixmapRect.top());
+
+    // Draw the outlined text
+    drawOutlinedText(painter, textRect, wrappedText, textOption);
 }
 
 /**

--- a/cockatrice/src/client/ui/widgets/general/display/labeled_input.cpp
+++ b/cockatrice/src/client/ui/widgets/general/display/labeled_input.cpp
@@ -1,0 +1,41 @@
+#include "labeled_input.h"
+
+LabeledInput::LabeledInput(const QString &labelText, QWidget *parent)
+        : QWidget(parent)
+{
+    label = new QLabel(labelText, this);
+    layout = new QHBoxLayout(this);
+    layout->addWidget(label);
+
+}
+
+QSpinBox* LabeledInput::addSpinBox(int minValue, int maxValue, int defaultValue)
+{
+    QSpinBox *spinBox = new QSpinBox(this);
+    spinBox->setRange(minValue, maxValue);
+    spinBox->setValue(defaultValue);
+    layout->addWidget(spinBox);
+    connect(spinBox, SIGNAL(valueChanged(int)), this, SIGNAL(spinBoxValueChanged(int)));
+    return spinBox;
+}
+
+// Add a QComboBox (for arbitrary selections)
+QComboBox* LabeledInput::addComboBox(const QStringList &items, const QString &defaultItem)
+{
+    QComboBox *comboBox = new QComboBox(this);
+    comboBox->addItems(items);
+    if (!defaultItem.isEmpty()) {
+        comboBox->setCurrentText(defaultItem);
+    }
+    layout->addWidget(comboBox);
+    return comboBox;
+}
+
+// Add a QComboBox specifically for Qt Directions
+QComboBox* LabeledInput::addDirectionComboBox()
+{
+    QStringList directions = {"Qt::Horizontal", "Qt::Vertical"};
+    auto comboBox = addComboBox(directions, "Qt::Vertical");
+    connect(comboBox, SIGNAL(currentTextChanged(QString)), this, SIGNAL(directionComboBoxChanged(QString)));
+    return comboBox;
+}

--- a/cockatrice/src/client/ui/widgets/general/display/labeled_input.cpp
+++ b/cockatrice/src/client/ui/widgets/general/display/labeled_input.cpp
@@ -1,15 +1,13 @@
 #include "labeled_input.h"
 
-LabeledInput::LabeledInput(const QString &labelText, QWidget *parent)
-        : QWidget(parent)
+LabeledInput::LabeledInput(const QString &labelText, QWidget *parent) : QWidget(parent)
 {
     label = new QLabel(labelText, this);
     layout = new QHBoxLayout(this);
     layout->addWidget(label);
-
 }
 
-QSpinBox* LabeledInput::addSpinBox(int minValue, int maxValue, int defaultValue)
+QSpinBox *LabeledInput::addSpinBox(int minValue, int maxValue, int defaultValue)
 {
     QSpinBox *spinBox = new QSpinBox(this);
     spinBox->setRange(minValue, maxValue);
@@ -20,7 +18,7 @@ QSpinBox* LabeledInput::addSpinBox(int minValue, int maxValue, int defaultValue)
 }
 
 // Add a QComboBox (for arbitrary selections)
-QComboBox* LabeledInput::addComboBox(const QStringList &items, const QString &defaultItem)
+QComboBox *LabeledInput::addComboBox(const QStringList &items, const QString &defaultItem)
 {
     QComboBox *comboBox = new QComboBox(this);
     comboBox->addItems(items);
@@ -32,7 +30,7 @@ QComboBox* LabeledInput::addComboBox(const QStringList &items, const QString &de
 }
 
 // Add a QComboBox specifically for Qt Directions
-QComboBox* LabeledInput::addDirectionComboBox()
+QComboBox *LabeledInput::addDirectionComboBox()
 {
     QStringList directions = {"Qt::Horizontal", "Qt::Vertical"};
     auto comboBox = addComboBox(directions, "Qt::Vertical");

--- a/cockatrice/src/client/ui/widgets/general/display/labeled_input.cpp
+++ b/cockatrice/src/client/ui/widgets/general/display/labeled_input.cpp
@@ -7,9 +7,9 @@ LabeledInput::LabeledInput(const QString &labelText, QWidget *parent) : QWidget(
     layout->addWidget(label);
 }
 
-QSpinBox *LabeledInput::addSpinBox(int minValue, int maxValue, int defaultValue)
+QSpinBox *LabeledInput::addSpinBox(const int minValue, const int maxValue, const int defaultValue)
 {
-    QSpinBox *spinBox = new QSpinBox(this);
+    auto *spinBox = new QSpinBox(this);
     spinBox->setRange(minValue, maxValue);
     spinBox->setValue(defaultValue);
     layout->addWidget(spinBox);
@@ -20,7 +20,7 @@ QSpinBox *LabeledInput::addSpinBox(int minValue, int maxValue, int defaultValue)
 // Add a QComboBox (for arbitrary selections)
 QComboBox *LabeledInput::addComboBox(const QStringList &items, const QString &defaultItem)
 {
-    QComboBox *comboBox = new QComboBox(this);
+    auto *comboBox = new QComboBox(this);
     comboBox->addItems(items);
     if (!defaultItem.isEmpty()) {
         comboBox->setCurrentText(defaultItem);
@@ -32,8 +32,8 @@ QComboBox *LabeledInput::addComboBox(const QStringList &items, const QString &de
 // Add a QComboBox specifically for Qt Directions
 QComboBox *LabeledInput::addDirectionComboBox()
 {
-    QStringList directions = {"Qt::Horizontal", "Qt::Vertical"};
-    auto comboBox = addComboBox(directions, "Qt::Vertical");
+    const QStringList directions = {"Qt::Horizontal", "Qt::Vertical"};
+    const auto comboBox = addComboBox(directions, "Qt::Vertical");
     connect(comboBox, SIGNAL(currentTextChanged(QString)), this, SIGNAL(directionComboBoxChanged(QString)));
     return comboBox;
 }

--- a/cockatrice/src/client/ui/widgets/general/display/labeled_input.cpp
+++ b/cockatrice/src/client/ui/widgets/general/display/labeled_input.cpp
@@ -1,6 +1,6 @@
 #include "labeled_input.h"
 
-LabeledInput::LabeledInput(const QString &labelText, QWidget *parent) : QWidget(parent)
+LabeledInput::LabeledInput(QWidget *parent, const QString &labelText) : QWidget(parent)
 {
     label = new QLabel(labelText, this);
     layout = new QHBoxLayout(this);

--- a/cockatrice/src/client/ui/widgets/general/display/labeled_input.h
+++ b/cockatrice/src/client/ui/widgets/general/display/labeled_input.h
@@ -7,12 +7,12 @@
 #include <QSpinBox>
 #include <QWidget>
 
-class LabeledInput : public QWidget
+class LabeledInput final : public QWidget
 {
     Q_OBJECT
 
 public:
-    LabeledInput(const QString &labelText, QWidget *parent = nullptr);
+    explicit LabeledInput(const QString &labelText, QWidget *parent = nullptr);
 
     // Add a QSpinBox (for arbitrary numbers)
     QSpinBox *addSpinBox(int minValue, int maxValue, int defaultValue = 0);

--- a/cockatrice/src/client/ui/widgets/general/display/labeled_input.h
+++ b/cockatrice/src/client/ui/widgets/general/display/labeled_input.h
@@ -12,7 +12,7 @@ class LabeledInput final : public QWidget
     Q_OBJECT
 
 public:
-    explicit LabeledInput(const QString &labelText, QWidget *parent = nullptr);
+    explicit LabeledInput(QWidget *parent, const QString &labelText);
 
     // Add a QSpinBox (for arbitrary numbers)
     QSpinBox *addSpinBox(int minValue, int maxValue, int defaultValue = 0);

--- a/cockatrice/src/client/ui/widgets/general/display/labeled_input.h
+++ b/cockatrice/src/client/ui/widgets/general/display/labeled_input.h
@@ -1,7 +1,3 @@
-//
-// Created by ascor on 10/11/24.
-//
-
 #ifndef LABELED_INPUT_H
 #define LABELED_INPUT_H
 

--- a/cockatrice/src/client/ui/widgets/general/display/labeled_input.h
+++ b/cockatrice/src/client/ui/widgets/general/display/labeled_input.h
@@ -5,10 +5,10 @@
 #ifndef LABELED_INPUT_H
 #define LABELED_INPUT_H
 
-#include <QLabel>
-#include <QSpinBox>
 #include <QComboBox>
 #include <QHBoxLayout>
+#include <QLabel>
+#include <QSpinBox>
 #include <QWidget>
 
 class LabeledInput : public QWidget
@@ -19,22 +19,22 @@ public:
     LabeledInput(const QString &labelText, QWidget *parent = nullptr);
 
     // Add a QSpinBox (for arbitrary numbers)
-    QSpinBox* addSpinBox(int minValue, int maxValue, int defaultValue = 0);
+    QSpinBox *addSpinBox(int minValue, int maxValue, int defaultValue = 0);
 
     // Add a QComboBox (for arbitrary selections)
-    QComboBox* addComboBox(const QStringList &items, const QString &defaultItem = QString());
+    QComboBox *addComboBox(const QStringList &items, const QString &defaultItem = QString());
 
     // Add a QComboBox specifically for Qt Directions
-    QComboBox* addDirectionComboBox();
+    QComboBox *addDirectionComboBox();
 
-    signals:
-        void spinBoxValueChanged(int newValue);  // Declare the valueChanged signal
-        void comboBoxValueChanged(int newValue);
-        void directionComboBoxChanged(QString newDirection);
+signals:
+    void spinBoxValueChanged(int newValue); // Declare the valueChanged signal
+    void comboBoxValueChanged(int newValue);
+    void directionComboBoxChanged(QString newDirection);
+
 private:
     QLabel *label;
     QHBoxLayout *layout;
 };
 
-
-#endif //LABELED_INPUT_H
+#endif // LABELED_INPUT_H

--- a/cockatrice/src/client/ui/widgets/general/display/labeled_input.h
+++ b/cockatrice/src/client/ui/widgets/general/display/labeled_input.h
@@ -1,0 +1,40 @@
+//
+// Created by ascor on 10/11/24.
+//
+
+#ifndef LABELED_INPUT_H
+#define LABELED_INPUT_H
+
+#include <QLabel>
+#include <QSpinBox>
+#include <QComboBox>
+#include <QHBoxLayout>
+#include <QWidget>
+
+class LabeledInput : public QWidget
+{
+    Q_OBJECT
+
+public:
+    LabeledInput(const QString &labelText, QWidget *parent = nullptr);
+
+    // Add a QSpinBox (for arbitrary numbers)
+    QSpinBox* addSpinBox(int minValue, int maxValue, int defaultValue = 0);
+
+    // Add a QComboBox (for arbitrary selections)
+    QComboBox* addComboBox(const QStringList &items, const QString &defaultItem = QString());
+
+    // Add a QComboBox specifically for Qt Directions
+    QComboBox* addDirectionComboBox();
+
+    signals:
+        void spinBoxValueChanged(int newValue);  // Declare the valueChanged signal
+        void comboBoxValueChanged(int newValue);
+        void directionComboBoxChanged(QString newDirection);
+private:
+    QLabel *label;
+    QHBoxLayout *layout;
+};
+
+
+#endif //LABELED_INPUT_H

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
@@ -96,7 +96,7 @@ void FlowWidget::clearLayout()
     if (flow_layout != nullptr) {
         QLayoutItem *item;
         while ((item = flow_layout->takeAt(0)) != nullptr) {
-            delete item->widget(); // Delete the widget
+            item->widget()->deleteLater(); // Delete the widget
             delete item;           // Delete the layout item
         }
     }

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
@@ -21,7 +21,9 @@
  * @param horizontalPolicy The horizontal scroll bar policy for the scroll area.
  * @param verticalPolicy The vertical scroll bar policy for the scroll area.
  */
-FlowWidget::FlowWidget(QWidget *parent, Qt::ScrollBarPolicy horizontalPolicy, Qt::ScrollBarPolicy verticalPolicy)
+FlowWidget::FlowWidget(QWidget *parent,
+                       const Qt::ScrollBarPolicy horizontalPolicy,
+                       const Qt::ScrollBarPolicy verticalPolicy)
     : QWidget(parent)
 {
     // Main Widget and Layout

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
@@ -97,7 +97,7 @@ void FlowWidget::clearLayout()
         QLayoutItem *item;
         while ((item = flow_layout->takeAt(0)) != nullptr) {
             item->widget()->deleteLater(); // Delete the widget
-            delete item;           // Delete the layout item
+            delete item;                   // Delete the layout item
         }
     } else {
         if (scrollArea->horizontalScrollBarPolicy() != Qt::ScrollBarAlwaysOff &&

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
@@ -38,7 +38,7 @@ FlowWidget::FlowWidget(QWidget *parent, Qt::ScrollBarPolicy horizontalPolicy, Qt
     } else if (horizontalPolicy == Qt::ScrollBarAlwaysOff && verticalPolicy != Qt::ScrollBarAlwaysOff) {
         flow_layout = new VerticalFlowLayout(container);
     } else {
-        flow_layout = new FlowLayout(container);
+        flow_layout = new FlowLayout(container, 0, 0, 0);
     }
 
     container->setLayout(flow_layout);
@@ -110,7 +110,7 @@ void FlowWidget::clearLayout()
                    scrollArea->verticalScrollBarPolicy() != Qt::ScrollBarAlwaysOff) {
             flow_layout = new VerticalFlowLayout(container);
         } else {
-            flow_layout = new FlowLayout(container);
+            flow_layout = new FlowLayout(container, 0, 0, 0);
         }
         this->container->setLayout(flow_layout);
     }

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
@@ -99,10 +99,7 @@ void FlowWidget::clearLayout()
             item->widget()->deleteLater(); // Delete the widget
             delete item;           // Delete the layout item
         }
-    }
-
-    // If layout is null, create a new layout, otherwise reuse the existing one
-    if (flow_layout == nullptr) {
+    } else {
         if (scrollArea->horizontalScrollBarPolicy() != Qt::ScrollBarAlwaysOff &&
             scrollArea->verticalScrollBarPolicy() == Qt::ScrollBarAlwaysOff) {
             flow_layout = new HorizontalFlowLayout(container);

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.cpp
@@ -1,0 +1,142 @@
+/**
+ * @file flow_widget.cpp
+ * @brief Implementation of the FlowWidget class for organizing widgets in a flow layout within a scrollable area.
+ */
+
+#include "flow_widget.h"
+
+#include "../../../layouts/flow_layout.h"
+#include "../../../layouts/horizontal_flow_layout.h"
+#include "../../../layouts/vertical_flow_layout.h"
+
+#include <QHBoxLayout>
+#include <QWidget>
+#include <qscrollarea.h>
+#include <qsizepolicy.h>
+
+/**
+ * @brief Constructs a FlowWidget with a scrollable layout.
+ *
+ * @param parent The parent widget of this FlowWidget.
+ * @param horizontalPolicy The horizontal scroll bar policy for the scroll area.
+ * @param verticalPolicy The vertical scroll bar policy for the scroll area.
+ */
+FlowWidget::FlowWidget(QWidget *parent, Qt::ScrollBarPolicy horizontalPolicy, Qt::ScrollBarPolicy verticalPolicy)
+    : QWidget(parent)
+{
+    // Main Widget and Layout
+    this->setMinimumSize(0, 0);
+    this->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    main_layout = new QHBoxLayout();
+    this->setLayout(main_layout);
+
+    // Flow Layout inside the scroll area
+    container = new QWidget();
+
+    if (horizontalPolicy != Qt::ScrollBarAlwaysOff && verticalPolicy == Qt::ScrollBarAlwaysOff) {
+        flow_layout = new HorizontalFlowLayout(container);
+    } else if (horizontalPolicy == Qt::ScrollBarAlwaysOff && verticalPolicy != Qt::ScrollBarAlwaysOff) {
+        flow_layout = new VerticalFlowLayout(container);
+    } else {
+        flow_layout = new FlowLayout(container);
+    }
+
+    container->setLayout(flow_layout);
+    // The container should expand as much as possible, trusting the scrollArea to constrain it.
+    container->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    container->setMinimumSize(0, 0);
+
+    // Scroll Area, which should expand as much as possible, since it should be the only direct child widget.
+    scrollArea = new QScrollArea();
+    scrollArea->setWidgetResizable(true);
+    scrollArea->setMinimumSize(0, 0);
+    scrollArea->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+    // Set scrollbar policies
+    scrollArea->setHorizontalScrollBarPolicy(horizontalPolicy);
+    scrollArea->setVerticalScrollBarPolicy(verticalPolicy);
+
+    // Use the FlowLayout container directly if we disable the ScrollArea
+    if (horizontalPolicy == Qt::ScrollBarAlwaysOff && verticalPolicy == Qt::ScrollBarAlwaysOff) {
+        main_layout->addWidget(container);
+    } else {
+        scrollArea->setWidget(container);
+        main_layout->addWidget(scrollArea);
+    }
+}
+
+/**
+ * @brief Adds a widget to the flow layout within the FlowWidget.
+ *
+ * Adjusts the widget's size policy based on the scroll bar policies.
+ *
+ * @param widget_to_add The widget to add to the flow layout.
+ */
+void FlowWidget::addWidget(QWidget *widget_to_add) const
+{
+    // Adjust size policy if scrollbars are disabled
+    if (scrollArea->horizontalScrollBarPolicy() == Qt::ScrollBarAlwaysOff) {
+        widget_to_add->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
+    }
+    if (scrollArea->verticalScrollBarPolicy() == Qt::ScrollBarAlwaysOff) {
+        widget_to_add->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Minimum);
+    }
+
+    // Add the widget to the flow layout
+    this->flow_layout->addWidget(widget_to_add);
+}
+
+/**
+ * @brief Clears all widgets from the flow layout.
+ *
+ * Deletes each widget and layout item, and recreates the flow layout if it was removed.
+ */
+void FlowWidget::clearLayout()
+{
+    if (flow_layout != nullptr) {
+        QLayoutItem *item;
+        while ((item = flow_layout->takeAt(0)) != nullptr) {
+            delete item->widget(); // Delete the widget
+            delete item;           // Delete the layout item
+        }
+    }
+
+    // If layout is null, create a new layout, otherwise reuse the existing one
+    if (flow_layout == nullptr) {
+        if (scrollArea->horizontalScrollBarPolicy() != Qt::ScrollBarAlwaysOff &&
+            scrollArea->verticalScrollBarPolicy() == Qt::ScrollBarAlwaysOff) {
+            flow_layout = new HorizontalFlowLayout(container);
+        } else if (scrollArea->horizontalScrollBarPolicy() == Qt::ScrollBarAlwaysOff &&
+                   scrollArea->verticalScrollBarPolicy() != Qt::ScrollBarAlwaysOff) {
+            flow_layout = new VerticalFlowLayout(container);
+        } else {
+            flow_layout = new FlowLayout(container);
+        }
+        this->container->setLayout(flow_layout);
+    }
+}
+
+/**
+ * @brief Handles resize events for the FlowWidget.
+ *
+ * Triggers layout recalculation and adjusts the scroll area content size.
+ *
+ * @param event The resize event containing the new size information.
+ */
+void FlowWidget::resizeEvent(QResizeEvent *event)
+{
+    QWidget::resizeEvent(event);
+
+    // Trigger the layout to recalculate
+    if (flow_layout != nullptr) {
+        flow_layout->invalidate(); // Marks the layout as dirty and requires recalculation
+        flow_layout->activate();   // Recalculate the layout based on the new size
+    }
+
+    // Ensure the scroll area and its content adjust correctly
+    if (scrollArea != nullptr) {
+        if (scrollArea->widget() != nullptr) {
+            scrollArea->widget()->adjustSize();
+        }
+    }
+}

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.h
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.h
@@ -1,0 +1,29 @@
+#ifndef FLOW_WIDGET_H
+#define FLOW_WIDGET_H
+#include "../../../layouts/flow_layout.h"
+
+#include <QHBoxLayout>
+#include <QWidget>
+#include <qscrollarea.h>
+
+class FlowWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    FlowWidget(QWidget *parent, Qt::ScrollBarPolicy hPolicy, Qt::ScrollBarPolicy vPolicy);
+    void addWidget(QWidget *widget_to_add) const;
+    void clearLayout();
+
+    QScrollArea *scrollArea;
+
+protected:
+    void resizeEvent(QResizeEvent *event) override;
+
+private:
+    QHBoxLayout *main_layout;
+    FlowLayout *flow_layout;
+    QWidget *container;
+};
+
+#endif // FLOW_WIDGET_H

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.h
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/flow_widget.h
@@ -6,12 +6,12 @@
 #include <QWidget>
 #include <qscrollarea.h>
 
-class FlowWidget : public QWidget
+class FlowWidget final : public QWidget
 {
     Q_OBJECT
 
 public:
-    FlowWidget(QWidget *parent, Qt::ScrollBarPolicy hPolicy, Qt::ScrollBarPolicy vPolicy);
+    FlowWidget(QWidget *parent, Qt::ScrollBarPolicy horizontalPolicy, Qt::ScrollBarPolicy verticalPolicy);
     void addWidget(QWidget *widget_to_add) const;
     void clearLayout();
 

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_control_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_control_widget.cpp
@@ -1,0 +1,39 @@
+#include "overlap_control_widget.h"
+
+#include "overlap_widget.h"
+
+OverlapControlWidget::OverlapControlWidget(int overlapPercentage, int maxColumns, int maxRows, Qt::Orientation direction, QWidget* parent)
+    : QWidget(parent), overlapPercentage(overlapPercentage), maxColumns(maxColumns), maxRows(maxRows), direction(direction)
+{
+    // Main Widget and Layout
+    this->setMinimumSize(0, 100);
+    //this->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    //this->setStyleSheet("border: 10px solid red;");
+
+    layout = new QHBoxLayout(this);
+    this->setLayout(layout);
+
+    card_size_slider = new QSlider(Qt::Horizontal);
+    card_size_slider->setRange(1, 10); // Example range for scaling, adjust as needed
+
+    amount_of_items_to_overlap = new LabeledInput("Cards to overlap:", this);
+    amount_of_items_to_overlap->addSpinBox(0, 999, 10);
+    overlap_percentage_input = new LabeledInput("Overlap percentage:", this);
+    overlap_percentage_input->addSpinBox(0, 100, 80);
+    overlap_direction = new LabeledInput("Overlap direction:", this);
+    overlap_direction->addDirectionComboBox();
+
+    layout->addWidget(card_size_slider);
+    layout->addWidget(amount_of_items_to_overlap);
+    layout->addWidget(overlap_percentage_input);
+    layout->addWidget(overlap_direction);
+
+    // TODO probably connect this to the parent
+    //connect(card_size_slider, &QSlider::valueChanged, display, &CardPicture::setScaleFactor);
+}
+
+void OverlapControlWidget::connectOverlapWidget(OverlapWidget *overlap_widget)
+{
+    connect(amount_of_items_to_overlap, &LabeledInput::spinBoxValueChanged, overlap_widget, &OverlapWidget::maxOverlapItemsChanged);
+    connect(overlap_direction, &LabeledInput::directionComboBoxChanged, overlap_widget, &OverlapWidget::overlapDirectionChanged);
+}

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_control_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_control_widget.cpp
@@ -21,11 +21,11 @@ OverlapControlWidget::OverlapControlWidget(int overlapPercentage,
     card_size_slider = new QSlider(Qt::Horizontal);
     card_size_slider->setRange(1, 10); // Example range for scaling, adjust as needed
 
-    amount_of_items_to_overlap = new LabeledInput("Cards to overlap:", this);
+    amount_of_items_to_overlap = new LabeledInput(this, tr("Cards to overlap:"));
     amount_of_items_to_overlap->addSpinBox(0, 999, 10);
-    overlap_percentage_input = new LabeledInput("Overlap percentage:", this);
+    overlap_percentage_input = new LabeledInput(this, tr("Overlap percentage:"));
     overlap_percentage_input->addSpinBox(0, 100, 80);
-    overlap_direction = new LabeledInput("Overlap direction:", this);
+    overlap_direction = new LabeledInput(this, tr("Overlap direction:"));
     overlap_direction->addDirectionComboBox();
 
     layout->addWidget(card_size_slider);

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_control_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_control_widget.cpp
@@ -2,13 +2,18 @@
 
 #include "overlap_widget.h"
 
-OverlapControlWidget::OverlapControlWidget(int overlapPercentage, int maxColumns, int maxRows, Qt::Orientation direction, QWidget* parent)
-    : QWidget(parent), overlapPercentage(overlapPercentage), maxColumns(maxColumns), maxRows(maxRows), direction(direction)
+OverlapControlWidget::OverlapControlWidget(int overlapPercentage,
+                                           int maxColumns,
+                                           int maxRows,
+                                           Qt::Orientation direction,
+                                           QWidget *parent)
+    : QWidget(parent), overlapPercentage(overlapPercentage), maxColumns(maxColumns), maxRows(maxRows),
+      direction(direction)
 {
     // Main Widget and Layout
     this->setMinimumSize(0, 100);
-    //this->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    //this->setStyleSheet("border: 10px solid red;");
+    // this->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    // this->setStyleSheet("border: 10px solid red;");
 
     layout = new QHBoxLayout(this);
     this->setLayout(layout);
@@ -29,11 +34,13 @@ OverlapControlWidget::OverlapControlWidget(int overlapPercentage, int maxColumns
     layout->addWidget(overlap_direction);
 
     // TODO probably connect this to the parent
-    //connect(card_size_slider, &QSlider::valueChanged, display, &CardPicture::setScaleFactor);
+    // connect(card_size_slider, &QSlider::valueChanged, display, &CardPicture::setScaleFactor);
 }
 
 void OverlapControlWidget::connectOverlapWidget(OverlapWidget *overlap_widget)
 {
-    connect(amount_of_items_to_overlap, &LabeledInput::spinBoxValueChanged, overlap_widget, &OverlapWidget::maxOverlapItemsChanged);
-    connect(overlap_direction, &LabeledInput::directionComboBoxChanged, overlap_widget, &OverlapWidget::overlapDirectionChanged);
+    connect(amount_of_items_to_overlap, &LabeledInput::spinBoxValueChanged, overlap_widget,
+            &OverlapWidget::maxOverlapItemsChanged);
+    connect(overlap_direction, &LabeledInput::directionComboBoxChanged, overlap_widget,
+            &OverlapWidget::overlapDirectionChanged);
 }

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_control_widget.h
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_control_widget.h
@@ -1,0 +1,35 @@
+#ifndef OVERLAP_CONTROL_WIDGET_H
+#define OVERLAP_CONTROL_WIDGET_H
+#include "../display/labeled_input.h"
+#include "overlap_widget.h"
+
+#include <QHBoxLayout>
+#include <QSlider>
+#include <QWidget>
+
+class OverlapControlWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    OverlapControlWidget(int overlapPercentage,
+                         int maxColumns,
+                         int maxRows,
+                         Qt::Orientation direction,
+                         QWidget *parent);
+    void connectOverlapWidget(OverlapWidget *overlap_widget);
+
+private:
+    QHBoxLayout *layout;
+    QSlider *card_size_slider;
+    LabeledInput *amount_of_items_to_overlap;
+    LabeledInput *overlap_percentage_input;
+    LabeledInput *overlap_direction;
+    int overlapPercentage;
+    int maxColumns;
+    int maxRows;
+    Qt::Orientation direction;
+
+};
+
+#endif //OVERLAP_CONTROL_WIDGET_H

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_control_widget.h
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_control_widget.h
@@ -7,7 +7,7 @@
 #include <QSlider>
 #include <QWidget>
 
-class OverlapControlWidget : public QWidget
+class OverlapControlWidget final : public QWidget
 {
     Q_OBJECT
 

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_control_widget.h
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_control_widget.h
@@ -29,7 +29,6 @@ private:
     int maxColumns;
     int maxRows;
     Qt::Orientation direction;
-
 };
 
-#endif //OVERLAP_CONTROL_WIDGET_H
+#endif // OVERLAP_CONTROL_WIDGET_H

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.cpp
@@ -42,7 +42,7 @@ OverlapWidget::OverlapWidget(QWidget *parent,
       direction(direction), adjustOnResize(adjustOnResize)
 {
     this->setMinimumSize(0, 0);
-    overlap_layout = new OverlapLayout(overlapPercentage, maxColumns, maxRows, direction, this);
+    overlap_layout = new OverlapLayout(this, overlapPercentage, maxColumns, maxRows, direction);
     this->setLayout(overlap_layout);
 }
 
@@ -79,7 +79,7 @@ void OverlapWidget::clearLayout()
 
     // If layout is null, create a new layout; otherwise, reuse the existing one
     if (overlap_layout == nullptr) {
-        overlap_layout = new OverlapLayout(overlapPercentage, maxColumns, maxRows, direction, this);
+        overlap_layout = new OverlapLayout(this, overlapPercentage, maxColumns, maxRows, direction);
         this->setLayout(overlap_layout);
     }
 }

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.cpp
@@ -1,0 +1,149 @@
+#include "overlap_widget.h"
+
+#include "../../../../../deck/deck_list_model.h"
+#include "../../../layouts/flow_layout.h"
+
+#include <QWidget>
+#include <qsizepolicy.h>
+
+/**
+ * @class OverlapWidget
+ * @brief A widget for managing overlapping child widgets.
+ *
+ * The OverlapWidget class is a QWidget subclass that utilizes the OverlapLayout
+ * to arrange its child widgets in an overlapping manner. This widget allows
+ * configuration of overlap percentage, maximum columns, maximum rows, and layout
+ * direction, making it suitable for displaying elements that can partially stack
+ * over each other. The widget automatically manages resizing and re-layout of its
+ * child widgets based on the available space and specified parameters.
+ */
+
+/**
+ * @brief Constructs an OverlapWidget with specified layout parameters.
+ *
+ * Initializes the OverlapWidget with the given overlap percentage, maximum number
+ * of columns and rows, and layout direction. Sets size policies to ensure the widget
+ * can expand as needed. A new OverlapLayout is created and assigned to manage the
+ * layout of child widgets.
+ *
+ * @param overlapPercentage The percentage of overlap between child widgets (0-100).
+ * @param maxColumns The maximum number of columns for the layout (0 for unlimited).
+ * @param maxRows The maximum number of rows for the layout (0 for unlimited).
+ * @param direction The orientation of the layout, either Qt::Horizontal or Qt::Vertical.
+ * @param parent The parent widget of this OverlapWidget.
+ */
+OverlapWidget::OverlapWidget(int overlapPercentage, int maxColumns, int maxRows, Qt::Orientation direction, QWidget* parent)
+    : QWidget(parent), overlapPercentage(overlapPercentage), maxColumns(maxColumns), maxRows(maxRows), direction(direction)
+{
+    this->setMinimumSize(0, 0);
+    this->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    overlap_layout = new OverlapLayout(overlapPercentage, maxColumns, maxRows, direction, this);
+    this->setLayout(overlap_layout);
+}
+
+/**
+ * @brief Adds a widget to the overlap layout.
+ *
+ * This method appends the specified widget to the internal OverlapLayout, allowing
+ * it to be arranged with the existing child widgets. The widget's visibility and
+ * behavior will be managed by the layout.
+ *
+ * @param widget_to_add A pointer to the QWidget to be added to the layout.
+ */
+void OverlapWidget::addWidget(QWidget *widget_to_add)
+{
+    this->overlap_layout->addWidget(widget_to_add);
+}
+
+/**
+ * @brief Clears all widgets from the layout and deletes them.
+ *
+ * This method removes all child widgets from the OverlapLayout, deleting both the
+ * widget instances and their corresponding layout items. This ensures that the layout
+ * is empty and can be reused or refreshed as needed.
+ */
+void OverlapWidget::clearLayout()
+{
+    if (overlap_layout != nullptr) {
+        QLayoutItem *item;
+        while ((item = overlap_layout->takeAt(0)) != nullptr) {
+            delete item->widget(); // Delete the widget
+            delete item;           // Delete the layout item
+        }
+    }
+
+    // If layout is null, create a new layout; otherwise, reuse the existing one
+    if (overlap_layout == nullptr) {
+        overlap_layout = new OverlapLayout(overlapPercentage, maxColumns, maxRows, direction, this);
+        this->setLayout(overlap_layout);
+    }
+}
+
+/**
+ * @brief Handles resizing events for the widget.
+ *
+ * This overridden method is called when the widget is resized. It invokes layout
+ * recalculation to ensure that the child widgets are correctly arranged based on the
+ * new dimensions. It marks the layout as dirty and activates it to reflect the changes.
+ *
+ * @param event The resize event containing the new size information.
+ */
+void OverlapWidget::resizeEvent(QResizeEvent* event) {
+    QWidget::resizeEvent(event);
+
+    // Trigger the layout to recalculate
+    if (overlap_layout != nullptr) {
+        overlap_layout->invalidate(); // Marks the layout as dirty and requires recalculation
+        overlap_layout->activate();   // Recalculate the layout based on the new size
+    }
+}
+
+/**
+ * @brief Updates the maximum number of overlapping items based on new value.
+ *
+ * This method updates the maximum number of columns or rows for the overlap layout
+ * based on the given new value. It adjusts the layout direction accordingly and
+ * triggers a size adjustment for the widget, ensuring the layout reflects the changes.
+ *
+ * @param newValue The new maximum number of overlapping items allowed in the layout.
+ */
+void OverlapWidget::maxOverlapItemsChanged(int newValue)
+{
+    if (direction == Qt::Horizontal) {
+        maxRows = 0;
+        overlap_layout->setMaxRows(0);
+
+        maxColumns = newValue;
+        overlap_layout->setMaxColumns(newValue);
+    } else {
+        maxRows = newValue;
+        overlap_layout->setMaxRows(newValue);
+
+        maxColumns = 0;
+        overlap_layout->setMaxColumns(0);
+    }
+    this->adjustSize();
+    overlap_layout->invalidate();
+}
+
+/**
+ * @brief Changes the layout direction based on the specified new direction.
+ *
+ * This method modifies the layout direction of the OverlapLayout based on the input
+ * string. It updates the direction and triggers a size adjustment for the widget.
+ * Valid inputs are "Qt::Horizontal" and "Qt::Vertical".
+ *
+ * @param newDirection The new layout direction as a QString.
+ */
+void OverlapWidget::overlapDirectionChanged(QString newDirection)
+{
+    if (newDirection.compare("Qt::Horizontal", Qt::CaseInsensitive) == 0) {
+        direction = Qt::Horizontal;
+        overlap_layout->setDirection(direction);
+    } else if (newDirection.compare("Qt::Vertical", Qt::CaseInsensitive) == 0) {
+        direction = Qt::Vertical;
+        overlap_layout->setDirection(direction);
+    }
+    this->adjustSize();
+    overlap_layout->invalidate();
+}

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.cpp
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.cpp
@@ -93,7 +93,8 @@ void OverlapWidget::clearLayout()
  *
  * @param event The resize event containing the new size information.
  */
-void OverlapWidget::resizeEvent(QResizeEvent* event) {
+void OverlapWidget::resizeEvent(QResizeEvent *event)
+{
     QWidget::resizeEvent(event);
 
     // Trigger the layout to recalculate

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.h
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.h
@@ -11,7 +11,12 @@ class OverlapWidget : public QWidget
     Q_OBJECT
 
 public:
-    OverlapWidget(QWidget *parent, int overlapPercentage, int maxColumns, int maxRows, Qt::Orientation direction, bool adjustOnResize = false);
+    OverlapWidget(QWidget *parent,
+                  int overlapPercentage,
+                  int maxColumns,
+                  int maxRows,
+                  Qt::Orientation direction,
+                  bool adjustOnResize = false);
     void addWidget(QWidget *widget_to_add);
     void clearLayout();
     void adjustMaxColumnsAndRows();
@@ -30,8 +35,6 @@ private:
     int maxRows;
     Qt::Orientation direction;
     bool adjustOnResize = false;
-
 };
 
-
-#endif //OVERLAP_WIDGET_H
+#endif // OVERLAP_WIDGET_H

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.h
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.h
@@ -11,9 +11,10 @@ class OverlapWidget : public QWidget
     Q_OBJECT
 
 public:
-    OverlapWidget(int overlapPercentage, int maxColumns, int maxRows, Qt::Orientation direction, QWidget *parent);
+    OverlapWidget(QWidget *parent, int overlapPercentage, int maxColumns, int maxRows, Qt::Orientation direction, bool adjustOnResize = false);
     void addWidget(QWidget *widget_to_add);
     void clearLayout();
+    void adjustMaxColumnsAndRows();
 
 public slots:
     void maxOverlapItemsChanged(int newValue);
@@ -28,6 +29,7 @@ private:
     int maxColumns;
     int maxRows;
     Qt::Orientation direction;
+    bool adjustOnResize = false;
 
 };
 

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.h
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.h
@@ -1,0 +1,35 @@
+#ifndef OVERLAP_WIDGET_H
+#define OVERLAP_WIDGET_H
+
+#include "../../../layouts/overlap_layout.h"
+
+#include <QHBoxLayout>
+#include <QWidget>
+
+class OverlapWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    OverlapWidget(int overlapPercentage, int maxColumns, int maxRows, Qt::Orientation direction, QWidget *parent);
+    void addWidget(QWidget *widget_to_add);
+    void clearLayout();
+
+public slots:
+    void maxOverlapItemsChanged(int newValue);
+    void overlapDirectionChanged(QString newDirection);
+
+protected:
+    void resizeEvent(QResizeEvent *event) override;
+
+private:
+    OverlapLayout *overlap_layout;
+    int overlapPercentage;
+    int maxColumns;
+    int maxRows;
+    Qt::Orientation direction;
+
+};
+
+
+#endif //OVERLAP_WIDGET_H

--- a/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.h
+++ b/cockatrice/src/client/ui/widgets/general/layout_containers/overlap_widget.h
@@ -3,10 +3,9 @@
 
 #include "../../../layouts/overlap_layout.h"
 
-#include <QHBoxLayout>
 #include <QWidget>
 
-class OverlapWidget : public QWidget
+class OverlapWidget final : public QWidget
 {
     Q_OBJECT
 
@@ -17,19 +16,19 @@ public:
                   int maxRows,
                   Qt::Orientation direction,
                   bool adjustOnResize = false);
-    void addWidget(QWidget *widget_to_add);
+    void addWidget(QWidget *widgetToAdd) const;
     void clearLayout();
     void adjustMaxColumnsAndRows();
 
 public slots:
     void maxOverlapItemsChanged(int newValue);
-    void overlapDirectionChanged(QString newDirection);
+    void overlapDirectionChanged(const QString &newDirection);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
 
 private:
-    OverlapLayout *overlap_layout;
+    OverlapLayout *overlapLayout;
     int overlapPercentage;
     int maxColumns;
     int maxRows;


### PR DESCRIPTION
## Short roundup of the initial problem

The default Qt layouts are insufficient for displaying a variable amount of variable size widgets. Qt themselves have a tutorial on how to construct a FlowLayout, which I've loosely adhered to, as far as best practices are concerned.
In any case, a FlowLayout is a useful tool to have and this change introduces it.
This also provides an OverlapLayout, which allows arbitrary Qt LayoutItems to be displayed in an overlapping fashion.

## What will change with this Pull Request?
- Introduce FlowLayout and FlowWidget
- Introduce OverlapLayout and OverlapWidget
